### PR TITLE
Add Postgres as an alternative backend to Redis

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,6 +24,19 @@ jobs:
                     --health-interval 5s
                     --health-timeout 5s
                     --health-retries 5
+            postgres:
+                image: postgres:latest
+                env:
+                    POSTGRES_USER: postgres
+                    POSTGRES_PASSWORD: postgres
+                    POSTGRES_DB: postgres
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd "pg_isready -U postgres"
+                    --health-interval 5s
+                    --health-timeout 5s
+                    --health-retries 5
 
         strategy:
             matrix:

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 [![npm version](https://badge.fury.io/js/%40anephenix%2Fjob-queue.svg)](https://badge.fury.io/js/%40anephenix%2Fjob-queue) [![Node.js CI](https://github.com/anephenix/job-queue/actions/workflows/node.js.yml/badge.svg)](https://github.com/anephenix/job-queue/actions/workflows/node.js.yml) [![Socket Badge](https://socket.dev/api/badge/npm/package/@anephenix/job-queue)](https://socket.dev/npm/package/@anephenix/job-queue)
 
-A Node.js Job Queue library using Redis.
+A Node.js Job Queue library using Redis or Postgres.
 
 ### Features
 
 -   Create job queues
 -   Create workers to process jobs on those queues
--   Store the queues and jobs in Redis for data persistence
+-   Store the queues and jobs in Redis or Postgres for data persistence
 -   Use hooks to trigger actions during the job lifecycle
 
 ### Dependencies
 
 -   [Node.js](https://nodejs.org)
--   [Redis](https://redis.io)
+-   [Redis](https://redis.io) or [Postgres](https://www.postgresql.org)
 
 ### Install
 
@@ -170,6 +170,58 @@ const queue = new Queue({
 	},
 });
 ```
+
+#### Using Postgres instead of Redis
+
+If you'd rather not run Redis, `PostgresQueue` provides the same API as
+`Queue`, backed by a Postgres table instead. You will need a `pg` Pool,
+made accessible to the queue files, perhaps in a postgres.ts file:
+
+```typescript
+// Dependencies
+import { Pool } from "pg";
+import config from "./config.ts";
+
+const pool = new Pool(config.postgres);
+
+export default pool;
+```
+
+Before using a queue for the first time, create its backing table by
+calling the `migrate` static method once (e.g. as part of your app's
+startup or a migration script). It is idempotent, so it's safe to call
+on every boot:
+
+```typescript
+import { PostgresQueue } from "@anephenix/job-queue";
+import pool from "./postgres.ts";
+
+await PostgresQueue.migrate(pool);
+```
+
+Then create a queue the same way you would with Redis:
+
+```typescript
+import pool from "./postgres.ts";
+import { PostgresQueue, type Hooks } from "@anephenix/job-queue";
+
+type QueueOptions = { queueKey: string; pg: typeof pool; hooks: Partial<Hooks> };
+const queueOptions: QueueOptions = { queueKey: "messages", pg: pool, hooks: {} };
+const messageQueue = new PostgresQueue(queueOptions);
+
+export default messageQueue;
+```
+
+`PostgresQueue` implements the same `add`, `take`, `complete`, `fail`,
+`release`, `retry`, `inspect`, `count`, `counts`, `flushAll` and `disconnect`
+methods as `Queue`, and hooks work identically. Because `Worker` only
+depends on that shared interface, `Worker` instances work unchanged
+with either `Queue` or `PostgresQueue`.
+
+All queues share one `job_queue_jobs` table by default, distinguished
+by `queueKey`, similarly to how Redis queues share one Redis instance
+distinguished by key prefixes. Pass a `tableName` option to `PostgresQueue`
+(and to `migrate`) if you'd like a queue to use its own table.
 
 ### License and Credits
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.3.29",
 			"license": "MIT",
 			"dependencies": {
+				"pg": "^8.23.0",
 				"redis": "^6.0.0"
 			},
 			"devDependencies": {
@@ -16,6 +17,7 @@
 				"@size-limit/file": "^13.0.1",
 				"@types/mocha": "^10.0.8",
 				"@types/node": "^26.0.0",
+				"@types/pg": "^8.21.0",
 				"@vitest/coverage-v8": "^4.0.16",
 				"globals": "^17.0.0",
 				"husky": "^9.1.6",
@@ -1154,6 +1156,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~8.3.0"
+			}
+		},
+		"node_modules/@types/pg": {
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.21.0.tgz",
+			"integrity": "sha512-AYdtudzabjLZgVgRZmAnU8bAnVUXzuJX2IYHeSIiIHm68olD+LgQYCGWdtcNYnP0uq9c4S4NibVG3Ni7VbKW7Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"pg-protocol": "*",
+				"pg-types": "^2.2.0"
 			}
 		},
 		"node_modules/@typescript/typescript-aix-ppc64": {
@@ -2329,6 +2343,95 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/pg": {
+			"version": "8.23.0",
+			"resolved": "https://registry.npmjs.org/pg/-/pg-8.23.0.tgz",
+			"integrity": "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==",
+			"license": "MIT",
+			"dependencies": {
+				"pg-connection-string": "^2.14.0",
+				"pg-pool": "^3.14.0",
+				"pg-protocol": "^1.16.0",
+				"pg-types": "2.2.0",
+				"pgpass": "1.0.5"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			},
+			"optionalDependencies": {
+				"pg-cloudflare": "^1.4.0"
+			},
+			"peerDependencies": {
+				"pg-native": ">=3.0.1"
+			},
+			"peerDependenciesMeta": {
+				"pg-native": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/pg-cloudflare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+			"integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/pg-connection-string": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+			"integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+			"license": "MIT"
+		},
+		"node_modules/pg-int8": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+			"integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/pg-pool": {
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+			"integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"pg": ">=8.0"
+			}
+		},
+		"node_modules/pg-protocol": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+			"integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
+			"license": "MIT"
+		},
+		"node_modules/pg-types": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+			"integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+			"license": "MIT",
+			"dependencies": {
+				"pg-int8": "1.0.1",
+				"postgres-array": "~2.0.0",
+				"postgres-bytea": "~1.0.0",
+				"postgres-date": "~1.0.4",
+				"postgres-interval": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pgpass": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+			"integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+			"license": "MIT",
+			"dependencies": {
+				"split2": "^4.1.0"
+			}
+		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2395,6 +2498,45 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/postgres-array": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+			"integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/postgres-bytea": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+			"integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/postgres-date": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+			"integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/postgres-interval": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+			"integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+			"license": "MIT",
+			"dependencies": {
+				"xtend": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/publint": {
@@ -2581,6 +2723,15 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/split2": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">= 10.x"
 			}
 		},
 		"node_modules/stackback": {
@@ -2905,6 +3056,15 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		}
 	},
 	"dependencies": {
+		"pg": "^8.23.0",
 		"redis": "^6.0.0"
 	},
 	"devDependencies": {
@@ -57,6 +58,7 @@
 		"@size-limit/file": "^13.0.1",
 		"@types/mocha": "^10.0.8",
 		"@types/node": "^26.0.0",
+		"@types/pg": "^8.21.0",
 		"@vitest/coverage-v8": "^4.0.16",
 		"globals": "^17.0.0",
 		"husky": "^9.1.6",

--- a/src/BaseQueue.ts
+++ b/src/BaseQueue.ts
@@ -1,0 +1,32 @@
+import type { Hook, Hooks, Job } from "./types.ts";
+
+abstract class BaseQueue {
+	hooks: Hooks;
+
+	constructor(hooks?: Partial<Hooks>) {
+		this.hooks = Object.assign(
+			{
+				add: { pre: null, post: null },
+				take: { pre: null, post: null },
+				complete: { pre: null, post: null },
+				fail: { pre: null, post: null },
+				release: { pre: null, post: null },
+				retry: { pre: null, post: null },
+				flushAll: { pre: null, post: null },
+			},
+			hooks,
+		);
+	}
+
+	protected async callHook(
+		action: keyof Hooks,
+		stage: keyof Hook,
+		job?: Job | undefined,
+	): Promise<void> {
+		if (typeof this.hooks[action][stage] === "function") {
+			return await this.hooks[action][stage]?.(job);
+		}
+	}
+}
+
+export { BaseQueue };

--- a/src/PostgresQueue.ts
+++ b/src/PostgresQueue.ts
@@ -1,0 +1,178 @@
+import type { Pool } from "pg";
+import { BaseQueue } from "./BaseQueue.js";
+import type {
+	Hooks,
+	Job,
+	JobQueue,
+	PostgresQueueOptions,
+	SubQueueKey,
+} from "./types.ts";
+
+const DEFAULT_TABLE_NAME = "job_queue_jobs";
+
+// Table names are interpolated into raw SQL (identifiers can't be
+// parameterized), so restrict them to a safe character set.
+const VALID_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+const assertValidTableName = (tableName: string): void => {
+	if (!VALID_IDENTIFIER.test(tableName)) {
+		throw new Error(`Invalid table name: ${tableName}`);
+	}
+};
+
+class PostgresQueue extends BaseQueue implements JobQueue {
+	pg: Pool;
+	queueKey: string;
+	tableName: string;
+
+	constructor({ queueKey, pg, hooks, tableName }: PostgresQueueOptions) {
+		super(hooks);
+		this.pg = pg;
+		this.queueKey = queueKey;
+		this.tableName = tableName || DEFAULT_TABLE_NAME;
+		assertValidTableName(this.tableName);
+	}
+
+	static async migrate(
+		pg: Pool,
+		tableName: string = DEFAULT_TABLE_NAME,
+	): Promise<void> {
+		assertValidTableName(tableName);
+		await pg.query(`
+			CREATE TABLE IF NOT EXISTS ${tableName} (
+				id BIGSERIAL PRIMARY KEY,
+				queue_key TEXT NOT NULL,
+				name TEXT NOT NULL,
+				data JSONB NOT NULL,
+				status TEXT NOT NULL DEFAULT 'available',
+				created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+				updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+			)
+		`);
+		await pg.query(`
+			CREATE INDEX IF NOT EXISTS ${tableName}_queue_status_id_idx
+				ON ${tableName} (queue_key, status, id)
+		`);
+	}
+
+	async disconnect(): Promise<void> {
+		await this.pg.end();
+	}
+
+	async add(job: Job): Promise<void> {
+		await this.callHook("add", "pre", job);
+		await this.pg.query(
+			`INSERT INTO ${this.tableName} (queue_key, name, data, status)
+			 VALUES ($1, $2, $3::jsonb, 'available')`,
+			[this.queueKey, job.name, JSON.stringify(job)],
+		);
+		return await this.callHook("add", "post", job);
+	}
+
+	async inspect(keyType: SubQueueKey = "available"): Promise<Job | null> {
+		const result = await this.pg.query(
+			`SELECT data FROM ${this.tableName}
+			 WHERE queue_key = $1 AND status = $2
+			 ORDER BY id DESC
+			 LIMIT 1`,
+			[this.queueKey, keyType],
+		);
+		if (result.rowCount === 0) return null;
+		return result.rows[0].data;
+	}
+
+	async count(keyType: SubQueueKey): Promise<number> {
+		const result = await this.pg.query(
+			`SELECT COUNT(*) FROM ${this.tableName}
+			 WHERE queue_key = $1 AND status = $2`,
+			[this.queueKey, keyType],
+		);
+		return Number.parseInt(result.rows[0].count, 10);
+	}
+
+	async counts(): Promise<{ [key: string]: number }> {
+		const [available, processing, failed, completed] = await Promise.all([
+			this.count("available"),
+			this.count("processing"),
+			this.count("failed"),
+			this.count("completed"),
+		]);
+		return {
+			available,
+			processing,
+			failed,
+			completed,
+		};
+	}
+
+	async take(): Promise<Job | null> {
+		await this.callHook("take", "pre");
+		const result = await this.pg.query(
+			`UPDATE ${this.tableName}
+			 SET status = 'processing', updated_at = now()
+			 WHERE id = (
+				SELECT id FROM ${this.tableName}
+				WHERE queue_key = $1 AND status = 'available'
+				ORDER BY id ASC
+				FOR UPDATE SKIP LOCKED
+				LIMIT 1
+			 )
+			 RETURNING data`,
+			[this.queueKey],
+		);
+		if (result.rowCount === 0) {
+			await this.callHook("take", "post");
+			return null;
+		}
+		const job = result.rows[0].data;
+		await this.callHook("take", "post", job);
+		return job;
+	}
+
+	private async conclude(
+		job: Job,
+		callHookAction: keyof Hooks,
+		toStatus: SubQueueKey,
+		fromStatus: SubQueueKey = "processing",
+	): Promise<void> {
+		await this.callHook(callHookAction, "pre", job);
+		await this.pg.query(
+			`UPDATE ${this.tableName}
+			 SET status = $1, updated_at = now()
+			 WHERE id = (
+				SELECT id FROM ${this.tableName}
+				WHERE queue_key = $2 AND status = $3 AND data = $4::jsonb
+				ORDER BY id ASC
+				LIMIT 1
+			 )`,
+			[toStatus, this.queueKey, fromStatus, JSON.stringify(job)],
+		);
+		return await this.callHook(callHookAction, "post", job);
+	}
+
+	async complete(job: Job): Promise<void> {
+		return await this.conclude(job, "complete", "completed");
+	}
+
+	async fail(job: Job): Promise<void> {
+		return await this.conclude(job, "fail", "failed");
+	}
+
+	async release(job: Job): Promise<void> {
+		return await this.conclude(job, "release", "available");
+	}
+
+	async retry(job: Job): Promise<void> {
+		return await this.conclude(job, "retry", "available", "failed");
+	}
+
+	async flushAll(): Promise<void> {
+		await this.callHook("flushAll", "pre");
+		await this.pg.query(`DELETE FROM ${this.tableName} WHERE queue_key = $1`, [
+			this.queueKey,
+		]);
+		await this.callHook("flushAll", "post");
+	}
+}
+
+export { PostgresQueue };

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -1,12 +1,13 @@
 import type { RedisClientType } from "redis";
-import type { Hook, Hooks, Job, QueueOptions } from "./types.ts";
+import { BaseQueue } from "./BaseQueue.js";
+import type { Hooks, Job, JobQueue, QueueOptions } from "./types.ts";
 
-class Queue {
+class Queue extends BaseQueue implements JobQueue {
 	redis: RedisClientType;
 	subQueueKeys: { [key: string]: string };
-	hooks: Hooks;
 
 	constructor({ queueKey, redis, hooks }: QueueOptions) {
+		super(hooks);
 		this.redis = redis;
 		this.subQueueKeys = {
 			available: `${queueKey}-available`,
@@ -14,18 +15,6 @@ class Queue {
 			completed: `${queueKey}-completed`,
 			failed: `${queueKey}-failed`,
 		};
-		this.hooks = Object.assign(
-			{
-				add: { pre: null, post: null },
-				take: { pre: null, post: null },
-				complete: { pre: null, post: null },
-				fail: { pre: null, post: null },
-				release: { pre: null, post: null },
-				retry: { pre: null, post: null },
-				flushAll: { pre: null, post: null },
-			},
-			hooks,
-		);
 		(async () => {
 			this.connect();
 		})();
@@ -38,16 +27,6 @@ class Queue {
 
 	async disconnect(): Promise<string> {
 		return await this.redis.quit();
-	}
-
-	private async callHook(
-		action: keyof Hooks,
-		stage: keyof Hook,
-		job?: Job | undefined,
-	): Promise<void> {
-		if (typeof this.hooks[action][stage] === "function") {
-			return await this.hooks[action][stage]?.(job);
-		}
 	}
 
 	async add(job: Job): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,15 @@
 // Dependencies
+import { PostgresQueue } from "./PostgresQueue.js";
 import { Queue } from "./Queue.js";
 import { Worker } from "./Worker.js";
 
-export type { Hook, Hooks, Job, QueueOptions } from "./types.js";
+export type {
+	Hook,
+	Hooks,
+	Job,
+	JobQueue,
+	PostgresQueueOptions,
+	QueueOptions,
+} from "./types.js";
 
-export { Queue, Worker };
+export { PostgresQueue, Queue, Worker };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { Pool } from "pg";
 import type { RedisClientType } from "redis";
 
 export interface Job {
@@ -24,4 +25,28 @@ export interface QueueOptions {
 	queueKey: string;
 	redis: RedisClientType;
 	hooks?: Partial<Hooks>;
+}
+
+export interface PostgresQueueOptions {
+	queueKey: string;
+	pg: Pool;
+	hooks?: Partial<Hooks>;
+	tableName?: string;
+}
+
+export type SubQueueKey = "available" | "processing" | "completed" | "failed";
+
+export interface JobQueue {
+	hooks: Hooks;
+	add(job: Job): Promise<void>;
+	inspect(keyType?: SubQueueKey): Promise<Job | null>;
+	count(keyType: SubQueueKey): Promise<number>;
+	counts(): Promise<{ [key: string]: number }>;
+	take(): Promise<Job | null>;
+	complete(job: Job): Promise<void>;
+	fail(job: Job): Promise<void>;
+	release(job: Job): Promise<void>;
+	retry(job: Job): Promise<void>;
+	flushAll(): Promise<void>;
+	disconnect(): Promise<unknown>;
 }

--- a/test/postgres.ts
+++ b/test/postgres.ts
@@ -1,0 +1,25 @@
+// Dependencies
+import { Pool, type PoolConfig } from "pg";
+
+const poolConfig: PoolConfig = {
+	host: process.env.POSTGRES_HOST || "localhost",
+	port: process.env.POSTGRES_PORT
+		? Number.parseInt(process.env.POSTGRES_PORT, 10)
+		: 5432,
+	user: process.env.POSTGRES_USER || "postgres",
+	password: process.env.POSTGRES_PASSWORD || "postgres",
+	database: process.env.POSTGRES_DB || "postgres",
+};
+
+let pgPool: Pool | null = null;
+
+const getPool = (): Pool => {
+	if (!pgPool) {
+		pgPool = new Pool(poolConfig);
+	}
+	return pgPool;
+};
+
+const createPool = (): Pool => new Pool(poolConfig);
+
+export { createPool, getPool };

--- a/test/src/PostgresQueue.test.ts
+++ b/test/src/PostgresQueue.test.ts
@@ -1,0 +1,242 @@
+// Dependencies
+import assert from "node:assert";
+import type { Pool } from "pg";
+import { beforeAll, describe, it } from "vitest";
+import { PostgresQueue } from "../../src/PostgresQueue";
+import type { Job, SubQueueKey } from "../../src/types";
+import { createPool, getPool } from "../postgres";
+
+const fetchLatest = async (
+	pool: Pool,
+	queueKey: string,
+	status: SubQueueKey,
+): Promise<Job | null> => {
+	const result = await pool.query(
+		"SELECT data FROM job_queue_jobs WHERE queue_key = $1 AND status = $2 ORDER BY id DESC LIMIT 1",
+		[queueKey, status],
+	);
+	if (result.rowCount === 0) return null;
+	return result.rows[0].data;
+};
+
+const prepareJob = async (
+	queue: PostgresQueue,
+	pool: Pool,
+	firstAction: keyof PostgresQueue,
+	subQueueKey: SubQueueKey,
+): Promise<void> => {
+	const anotherJob: Job = { name: "Another example job" };
+	await queue.add(anotherJob);
+	await queue.take();
+	const action = queue[firstAction] as (
+		this: PostgresQueue,
+		job: Job,
+	) => Promise<void>;
+	if (typeof action === "function") {
+		await action.call(queue, anotherJob);
+	} else {
+		throw new Error(`queue[${String(firstAction)}] is not a function`);
+	}
+	const processingJob = await fetchLatest(pool, queue.queueKey, "processing");
+	const concludedJob = await fetchLatest(pool, queue.queueKey, subQueueKey);
+	if (!concludedJob) {
+		throw new Error("Jobs not found in queue");
+	}
+	assert.equal(processingJob, null);
+	assert.deepEqual(concludedJob, anotherJob);
+};
+
+describe("PostgresQueue", () => {
+	let queue: PostgresQueue;
+	let job: Job;
+	const pool: Pool = getPool();
+
+	beforeAll(async () => {
+		await PostgresQueue.migrate(pool);
+		const queueKey = "example-pg-queue";
+		queue = new PostgresQueue({ queueKey, pg: pool });
+		await queue.flushAll();
+		job = { name: "example-job" };
+	});
+
+	describe("creating an instance", () => {
+		it("should set the pg pool", () => {
+			assert.deepEqual(pool, queue.pg);
+		});
+		it("should set the queueKey", () => {
+			assert.equal(queue.queueKey, "example-pg-queue");
+		});
+	});
+
+	describe("adding a job", () => {
+		it("should add a job to the available queue", async () => {
+			await queue.add(job);
+			const fetchedJob = await queue.inspect();
+			assert.deepEqual(job, fetchedJob);
+		});
+	});
+
+	describe("inspecting a job", () => {
+		it("should return the latest job on the available queue", async () => {
+			const fetchedJob = await queue.inspect();
+			assert.deepEqual(job, fetchedJob);
+		});
+
+		it("should return null if there are no available jobs on the queue", async () => {
+			const queueKey = "this-example-pg-queue";
+			const anotherQueue = new PostgresQueue({ queueKey, pg: pool });
+			await anotherQueue.flushAll();
+			const result = await anotherQueue.inspect();
+			assert.equal(result, null);
+		});
+	});
+
+	describe("taking a job", () => {
+		it("should move a job from the available queue to the processing queue", async () => {
+			const fetchedJob = await queue.take();
+			assert.deepEqual(job, fetchedJob);
+			const pgJob = await fetchLatest(pool, queue.queueKey, "processing");
+			if (!pgJob) {
+				throw new Error("Job not found in queue");
+			}
+			assert.deepEqual(pgJob, fetchedJob);
+		});
+	});
+
+	describe("completing a job", () => {
+		it("should move a job from the processing queue to the completed queue", async () => {
+			const processingJob = await fetchLatest(
+				pool,
+				queue.queueKey,
+				"processing",
+			);
+			if (!processingJob) {
+				throw new Error("Job not found in queue");
+			}
+			await queue.complete(processingJob);
+			const stillProcessingJob = await fetchLatest(
+				pool,
+				queue.queueKey,
+				"processing",
+			);
+			const completedJob = await fetchLatest(pool, queue.queueKey, "completed");
+			if (!completedJob) {
+				throw new Error("completedJob not found in queue");
+			}
+			assert.equal(stillProcessingJob, null);
+			assert.deepEqual(completedJob, processingJob);
+		});
+	});
+
+	describe("failing a job", () => {
+		it("should move a job from the processing queue to the failed queue", async () => {
+			await prepareJob(queue, pool, "fail", "failed");
+		});
+	});
+
+	describe("releasing a job", () => {
+		it("should move a job from the processing queue to the available queue", async () => {
+			await prepareJob(queue, pool, "release", "available");
+		});
+	});
+
+	describe("retrying a job", () => {
+		it("should move a job from the failed queue to the available queue", async () => {
+			await queue.flushAll();
+			await prepareJob(queue, pool, "fail", "failed");
+			const failedJob = await fetchLatest(pool, queue.queueKey, "failed");
+			if (!failedJob) {
+				throw new Error("Job not found in queue");
+			}
+			await queue.retry(failedJob);
+			const stillFailedJob = await fetchLatest(pool, queue.queueKey, "failed");
+			const availableJob = await fetchLatest(pool, queue.queueKey, "available");
+			if (!availableJob) {
+				throw new Error("Jobs not found in queue");
+			}
+			assert.equal(stillFailedJob, null);
+			assert.deepEqual(availableJob, failedJob);
+		});
+	});
+
+	describe("flushing all jobs", () => {
+		it("should remove all jobs from all queues", async () => {
+			await queue.flushAll();
+			const available = await fetchLatest(pool, queue.queueKey, "available");
+			const processing = await fetchLatest(pool, queue.queueKey, "processing");
+			const completed = await fetchLatest(pool, queue.queueKey, "completed");
+			const failed = await fetchLatest(pool, queue.queueKey, "failed");
+			assert.equal(available, null);
+			assert.equal(processing, null);
+			assert.equal(completed, null);
+			assert.equal(failed, null);
+		});
+	});
+
+	describe("hooks", () => {
+		it("should allow the developer to add pre and post hooks to called actions", async () => {
+			const queueKey = "another-example-pg-queue";
+			let jobParam: Job | undefined;
+			const hookQueue = new PostgresQueue({
+				queueKey,
+				pg: pool,
+				hooks: {
+					add: {
+						pre: async (job) => {
+							jobParam = job;
+							return Promise.resolve();
+						},
+					},
+				},
+			});
+			const hookJob = { name: "example-job" };
+			await hookQueue.add(hookJob);
+			assert.deepEqual(jobParam, hookJob);
+		});
+	});
+
+	describe("count", () => {
+		const queueKey = "another-example-pg-queue-count";
+		const countQueue = new PostgresQueue({ queueKey, pg: pool });
+
+		beforeAll(async () => {
+			await countQueue.flushAll();
+			const initialCount = await countQueue.count("available");
+			assert.equal(initialCount, 0);
+			await countQueue.add({ name: "example-job" });
+		});
+
+		it("should return the number of jobs in a queue with a specific status", async () => {
+			const updatedCount = await countQueue.count("available");
+			assert.equal(updatedCount, 1);
+		});
+	});
+
+	describe("counts", () => {
+		it("should return the number of jobs in a queue, for each status", async () => {
+			await queue.flushAll();
+			await queue.add({ name: "example-job" });
+			const counts = await queue.counts();
+			assert.deepEqual(counts, {
+				available: 1,
+				processing: 0,
+				completed: 0,
+				failed: 0,
+			});
+			await queue.flushAll();
+		});
+	});
+
+	describe("disconnect", () => {
+		it("should disconnect from the postgres pool", async () => {
+			const anotherPool = createPool();
+			await anotherPool.query("SELECT 1");
+			const anotherQueue = new PostgresQueue({
+				queueKey: "other-pg-queue",
+				pg: anotherPool,
+			});
+			await anotherQueue.disconnect();
+			await assert.rejects(() => anotherPool.query("SELECT 1"));
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Adds `PostgresQueue`, a Postgres-backed implementation of the same public API as `Queue` (`add`/`take`/`complete`/`fail`/`release`/`retry`/`inspect`/`count`/`counts`/`flushAll`/`disconnect`), so it's a drop-in alternative wherever `Queue` is used today.
- Extracts shared hooks logic into `BaseQueue` so both backends share the pre/post hook plumbing instead of duplicating it.
- `Worker` needed no changes — it was already backend-agnostic, so it works unchanged with either `Queue` (Redis) or `PostgresQueue`.
- Adds a `PostgresQueue.migrate(pool)` helper for idempotent schema setup (single `job_queue_jobs` table, keyed by `queue_key`/`status`, using `FOR UPDATE SKIP LOCKED` for safe concurrent `take()`).
- CI now spins up a `postgres:latest` service alongside `redis`.
- README documents the new Postgres usage path.

## Test plan
- [x] `npm run build` (tsc) — clean
- [x] `npm run lint` (biome) — clean on all changed files
- [x] `npm t` — 54/54 tests pass locally (39 existing Redis tests unaffected by the `BaseQueue` refactor, 15 new `PostgresQueue` tests) against local Redis + Postgres instances
- [x] CI workflow updated to provision Postgres for the new test suite