### PR TITLE
Add SQLite as an alternative backend to Redis and Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 [![npm version](https://badge.fury.io/js/%40anephenix%2Fjob-queue.svg)](https://badge.fury.io/js/%40anephenix%2Fjob-queue) [![Node.js CI](https://github.com/anephenix/job-queue/actions/workflows/node.js.yml/badge.svg)](https://github.com/anephenix/job-queue/actions/workflows/node.js.yml) [![Socket Badge](https://socket.dev/api/badge/npm/package/@anephenix/job-queue)](https://socket.dev/npm/package/@anephenix/job-queue)
 
-A Node.js Job Queue library using Redis or Postgres.
+A Node.js Job Queue library using Redis, Postgres or SQLite.
 
 ### Features
 
 -   Create job queues
 -   Create workers to process jobs on those queues
--   Store the queues and jobs in Redis or Postgres for data persistence
+-   Store the queues and jobs in Redis, Postgres or SQLite for data persistence
 -   Use hooks to trigger actions during the job lifecycle
 
 ### Dependencies
 
 -   [Node.js](https://nodejs.org)
--   [Redis](https://redis.io) or [Postgres](https://www.postgresql.org)
+-   [Redis](https://redis.io), [Postgres](https://www.postgresql.org) or [SQLite](https://www.sqlite.org) (via [better-sqlite3](https://github.com/WiseLibs/better-sqlite3))
 
 ### Install
 
@@ -222,6 +222,66 @@ All queues share one `job_queue_jobs` table by default, distinguished
 by `queueKey`, similarly to how Redis queues share one Redis instance
 distinguished by key prefixes. Pass a `tableName` option to `PostgresQueue`
 (and to `migrate`) if you'd like a queue to use its own table.
+
+#### Using SQLite instead of Redis or Postgres
+
+If you'd rather not run a database server at all, `SQLiteQueue` provides
+the same API as `Queue` and `PostgresQueue`, backed by a local SQLite file
+via [better-sqlite3](https://github.com/WiseLibs/better-sqlite3). This
+works well when your queues and workers all run on the same machine (or
+share the same local disk); SQLite's file locking handles the concurrent
+access, so no separate database process is required. You will need a
+`better-sqlite3` `Database` instance, made accessible to the queue files,
+perhaps in a sqlite.ts file:
+
+```typescript
+// Dependencies
+import Database from "better-sqlite3";
+
+const db = new Database("./job-queue.db");
+
+export default db;
+```
+
+Before using a queue for the first time, create its backing table by
+calling the `migrate` static method once (e.g. as part of your app's
+startup or a migration script). It is idempotent, so it's safe to call
+on every boot:
+
+```typescript
+import { SQLiteQueue } from "@anephenix/job-queue";
+import db from "./sqlite.ts";
+
+SQLiteQueue.migrate(db);
+```
+
+Then create a queue the same way you would with Redis or Postgres:
+
+```typescript
+import db from "./sqlite.ts";
+import { SQLiteQueue, type Hooks } from "@anephenix/job-queue";
+
+type QueueOptions = { queueKey: string; db: typeof db; hooks: Partial<Hooks> };
+const queueOptions: QueueOptions = { queueKey: "messages", db, hooks: {} };
+const messageQueue = new SQLiteQueue(queueOptions);
+
+export default messageQueue;
+```
+
+`SQLiteQueue` implements the same `add`, `take`, `complete`, `fail`,
+`release`, `retry`, `inspect`, `count`, `counts`, `flushAll` and `disconnect`
+methods as `Queue` and `PostgresQueue`, and hooks work identically. All
+queues share one `job_queue_jobs` table by default, distinguished by
+`queueKey`, and accept a `tableName` option the same way `PostgresQueue`
+does.
+
+Because SQLite only ever allows one writer at a time, `take()` claims jobs
+inside an immediate write transaction rather than relying on something
+like Postgres's `FOR UPDATE SKIP LOCKED` — the effect for callers is the
+same (no two workers are ever handed the same job), just serialized rather
+than parallelized at the storage layer. If your workers need to run across
+multiple machines, use `Queue` or `PostgresQueue` instead, since SQLite
+requires all processes to share the same local disk.
 
 ### License and Credits
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
 			"version": "1.4.0",
 			"license": "MIT",
 			"dependencies": {
+				"better-sqlite3": "^13.0.3",
 				"pg": "^8.23.0",
 				"redis": "^6.0.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.7",
 				"@size-limit/file": "^13.0.1",
+				"@types/better-sqlite3": "^9.6.0",
 				"@types/mocha": "^10.0.8",
 				"@types/node": "^26.0.0",
 				"@types/pg": "^8.21.0",
@@ -1116,6 +1118,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/better-sqlite3": {
+			"version": "9.6.0",
+			"resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+			"integrity": "sha512-ZEEwBSgMu7GYJOynoagg5X9JbxfL6dTJDsgViJIqh67jV44kyOr9RXfmFjLK5rzC4MWssP06t9hu/JwGDnUbCg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/chai": {
 			"version": "5.2.3",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1674,6 +1686,18 @@
 				"@jridgewell/trace-mapping": "^0.3.31",
 				"estree-walker": "^3.0.3",
 				"js-tokens": "^10.0.0"
+			}
+		},
+		"node_modules/better-sqlite3": {
+			"version": "13.0.3",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
+			"integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+			"license": "MIT",
+			"dependencies": {
+				"node-addon-api": "^8.0.0"
+			},
+			"engines": {
+				"node": ">=22"
 			}
 		},
 		"node_modules/bytes-iec": {
@@ -2313,6 +2337,15 @@
 			"license": "MIT",
 			"dependencies": {
 				"picocolors": "^1.1.1"
+			}
+		},
+		"node_modules/node-addon-api": {
+			"version": "8.9.2",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+			"integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
+			"license": "MIT",
+			"engines": {
+				"node": "^18 || ^20 || >= 21"
 			}
 		},
 		"node_modules/obug": {

--- a/package.json
+++ b/package.json
@@ -50,12 +50,14 @@
 		}
 	},
 	"dependencies": {
+		"better-sqlite3": "^13.0.3",
 		"pg": "^8.23.0",
 		"redis": "^6.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.7",
 		"@size-limit/file": "^13.0.1",
+		"@types/better-sqlite3": "^9.6.0",
 		"@types/mocha": "^10.0.8",
 		"@types/node": "^26.0.0",
 		"@types/pg": "^8.21.0",

--- a/src/SQLiteQueue.ts
+++ b/src/SQLiteQueue.ts
@@ -1,0 +1,190 @@
+import type { Database } from "better-sqlite3";
+import { BaseQueue } from "./BaseQueue.js";
+import type {
+	Hooks,
+	Job,
+	JobQueue,
+	SQLiteQueueOptions,
+	SubQueueKey,
+} from "./types.ts";
+
+const DEFAULT_TABLE_NAME = "job_queue_jobs";
+
+// Table names are interpolated into raw SQL (identifiers can't be
+// parameterized), so restrict them to a safe character set.
+const VALID_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+const assertValidTableName = (tableName: string): void => {
+	if (!VALID_IDENTIFIER.test(tableName)) {
+		throw new Error(`Invalid table name: ${tableName}`);
+	}
+};
+
+class SQLiteQueue extends BaseQueue implements JobQueue {
+	db: Database;
+	queueKey: string;
+	tableName: string;
+
+	constructor({ queueKey, db, hooks, tableName }: SQLiteQueueOptions) {
+		super(hooks);
+		this.db = db;
+		this.queueKey = queueKey;
+		this.tableName = tableName || DEFAULT_TABLE_NAME;
+		assertValidTableName(this.tableName);
+
+		// WAL mode allows other processes with a handle on the same file to
+		// read and write concurrently; busy_timeout makes a writer wait for
+		// a lock instead of throwing SQLITE_BUSY immediately.
+		this.db.pragma("journal_mode = WAL");
+		this.db.pragma("busy_timeout = 5000");
+	}
+
+	static migrate(db: Database, tableName: string = DEFAULT_TABLE_NAME): void {
+		assertValidTableName(tableName);
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS ${tableName} (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				queue_key TEXT NOT NULL,
+				name TEXT NOT NULL,
+				data TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'available',
+				created_at INTEGER NOT NULL DEFAULT (unixepoch('subsec') * 1000),
+				updated_at INTEGER NOT NULL DEFAULT (unixepoch('subsec') * 1000)
+			)
+		`);
+		db.exec(`
+			CREATE INDEX IF NOT EXISTS ${tableName}_queue_status_id_idx
+				ON ${tableName} (queue_key, status, id)
+		`);
+	}
+
+	async disconnect(): Promise<void> {
+		this.db.close();
+	}
+
+	async add(job: Job): Promise<void> {
+		await this.callHook("add", "pre", job);
+		this.db
+			.prepare(
+				`INSERT INTO ${this.tableName} (queue_key, name, data, status)
+				 VALUES (?, ?, ?, 'available')`,
+			)
+			.run(this.queueKey, job.name, JSON.stringify(job));
+		return await this.callHook("add", "post", job);
+	}
+
+	async inspect(keyType: SubQueueKey = "available"): Promise<Job | null> {
+		const row = this.db
+			.prepare(
+				`SELECT data FROM ${this.tableName}
+				 WHERE queue_key = ? AND status = ?
+				 ORDER BY id DESC
+				 LIMIT 1`,
+			)
+			.get(this.queueKey, keyType) as { data: string } | undefined;
+		return row ? JSON.parse(row.data) : null;
+	}
+
+	async count(keyType: SubQueueKey): Promise<number> {
+		const row = this.db
+			.prepare(
+				`SELECT COUNT(*) AS count FROM ${this.tableName}
+				 WHERE queue_key = ? AND status = ?`,
+			)
+			.get(this.queueKey, keyType) as { count: number };
+		return row.count;
+	}
+
+	async counts(): Promise<{ [key: string]: number }> {
+		const [available, processing, failed, completed] = await Promise.all([
+			this.count("available"),
+			this.count("processing"),
+			this.count("failed"),
+			this.count("completed"),
+		]);
+		return {
+			available,
+			processing,
+			failed,
+			completed,
+		};
+	}
+
+	// Postgres uses FOR UPDATE SKIP LOCKED so several workers can each claim
+	// a different row at the same time. SQLite only ever allows one writer,
+	// so BEGIN IMMEDIATE achieves the same outcome (no two workers ever get
+	// the same job) by serializing claims rather than skipping locked rows.
+	async take(): Promise<Job | null> {
+		await this.callHook("take", "pre");
+		const claim = this.db.transaction(() => {
+			const row = this.db
+				.prepare(
+					`SELECT id, data FROM ${this.tableName}
+					 WHERE queue_key = ? AND status = 'available'
+					 ORDER BY id ASC
+					 LIMIT 1`,
+				)
+				.get(this.queueKey) as { id: number; data: string } | undefined;
+			if (!row) return null;
+			this.db
+				.prepare(
+					`UPDATE ${this.tableName}
+					 SET status = 'processing', updated_at = unixepoch('subsec') * 1000
+					 WHERE id = ?`,
+				)
+				.run(row.id);
+			return JSON.parse(row.data) as Job;
+		});
+		const job = claim.immediate();
+		await this.callHook("take", "post", job ?? undefined);
+		return job;
+	}
+
+	private async conclude(
+		job: Job,
+		callHookAction: keyof Hooks,
+		toStatus: SubQueueKey,
+		fromStatus: SubQueueKey = "processing",
+	): Promise<void> {
+		await this.callHook(callHookAction, "pre", job);
+		this.db
+			.prepare(
+				`UPDATE ${this.tableName}
+				 SET status = ?, updated_at = unixepoch('subsec') * 1000
+				 WHERE id = (
+					SELECT id FROM ${this.tableName}
+					WHERE queue_key = ? AND status = ? AND data = ?
+					ORDER BY id ASC
+					LIMIT 1
+				 )`,
+			)
+			.run(toStatus, this.queueKey, fromStatus, JSON.stringify(job));
+		return await this.callHook(callHookAction, "post", job);
+	}
+
+	async complete(job: Job): Promise<void> {
+		return await this.conclude(job, "complete", "completed");
+	}
+
+	async fail(job: Job): Promise<void> {
+		return await this.conclude(job, "fail", "failed");
+	}
+
+	async release(job: Job): Promise<void> {
+		return await this.conclude(job, "release", "available");
+	}
+
+	async retry(job: Job): Promise<void> {
+		return await this.conclude(job, "retry", "available", "failed");
+	}
+
+	async flushAll(): Promise<void> {
+		await this.callHook("flushAll", "pre");
+		this.db
+			.prepare(`DELETE FROM ${this.tableName} WHERE queue_key = ?`)
+			.run(this.queueKey);
+		await this.callHook("flushAll", "post");
+	}
+}
+
+export { SQLiteQueue };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 // Dependencies
 import { PostgresQueue } from "./PostgresQueue.js";
 import { Queue } from "./Queue.js";
+import { SQLiteQueue } from "./SQLiteQueue.js";
 import { Worker } from "./Worker.js";
 
 export type {
@@ -10,6 +11,7 @@ export type {
 	JobQueue,
 	PostgresQueueOptions,
 	QueueOptions,
+	SQLiteQueueOptions,
 } from "./types.js";
 
-export { PostgresQueue, Queue, Worker };
+export { PostgresQueue, Queue, SQLiteQueue, Worker };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { Database } from "better-sqlite3";
 import type { Pool } from "pg";
 import type { RedisClientType } from "redis";
 
@@ -30,6 +31,13 @@ export interface QueueOptions {
 export interface PostgresQueueOptions {
 	queueKey: string;
 	pg: Pool;
+	hooks?: Partial<Hooks>;
+	tableName?: string;
+}
+
+export interface SQLiteQueueOptions {
+	queueKey: string;
+	db: Database;
 	hooks?: Partial<Hooks>;
 	tableName?: string;
 }

--- a/test/sqlite.ts
+++ b/test/sqlite.ts
@@ -1,0 +1,15 @@
+// Dependencies
+import Database from "better-sqlite3";
+
+let db: Database.Database | null = null;
+
+const getDb = (): Database.Database => {
+	if (!db) {
+		db = new Database(":memory:");
+	}
+	return db;
+};
+
+const createDb = (): Database.Database => new Database(":memory:");
+
+export { createDb, getDb };

--- a/test/src/SQLiteQueue.test.ts
+++ b/test/src/SQLiteQueue.test.ts
@@ -1,0 +1,234 @@
+// Dependencies
+import assert from "node:assert";
+import type { Database } from "better-sqlite3";
+import { beforeAll, describe, it } from "vitest";
+import { SQLiteQueue } from "../../src/SQLiteQueue";
+import type { Job, SubQueueKey } from "../../src/types";
+import { createDb, getDb } from "../sqlite";
+
+const fetchLatest = (
+	db: Database,
+	queueKey: string,
+	status: SubQueueKey,
+): Job | null => {
+	const row = db
+		.prepare(
+			"SELECT data FROM job_queue_jobs WHERE queue_key = ? AND status = ? ORDER BY id DESC LIMIT 1",
+		)
+		.get(queueKey, status) as { data: string } | undefined;
+	return row ? JSON.parse(row.data) : null;
+};
+
+const prepareJob = async (
+	queue: SQLiteQueue,
+	db: Database,
+	firstAction: keyof SQLiteQueue,
+	subQueueKey: SubQueueKey,
+): Promise<void> => {
+	const anotherJob: Job = { name: "Another example job" };
+	await queue.add(anotherJob);
+	await queue.take();
+	const action = queue[firstAction] as (
+		this: SQLiteQueue,
+		job: Job,
+	) => Promise<void>;
+	if (typeof action === "function") {
+		await action.call(queue, anotherJob);
+	} else {
+		throw new Error(`queue[${String(firstAction)}] is not a function`);
+	}
+	const processingJob = fetchLatest(db, queue.queueKey, "processing");
+	const concludedJob = fetchLatest(db, queue.queueKey, subQueueKey);
+	if (!concludedJob) {
+		throw new Error("Jobs not found in queue");
+	}
+	assert.equal(processingJob, null);
+	assert.deepEqual(concludedJob, anotherJob);
+};
+
+describe("SQLiteQueue", () => {
+	let queue: SQLiteQueue;
+	let job: Job;
+	const db: Database = getDb();
+
+	beforeAll(async () => {
+		SQLiteQueue.migrate(db);
+		const queueKey = "example-sqlite-queue";
+		queue = new SQLiteQueue({ queueKey, db });
+		await queue.flushAll();
+		job = { name: "example-job" };
+	});
+
+	describe("creating an instance", () => {
+		it("should set the db", () => {
+			assert.deepEqual(db, queue.db);
+		});
+		it("should set the queueKey", () => {
+			assert.equal(queue.queueKey, "example-sqlite-queue");
+		});
+	});
+
+	describe("adding a job", () => {
+		it("should add a job to the available queue", async () => {
+			await queue.add(job);
+			const fetchedJob = await queue.inspect();
+			assert.deepEqual(job, fetchedJob);
+		});
+	});
+
+	describe("inspecting a job", () => {
+		it("should return the latest job on the available queue", async () => {
+			const fetchedJob = await queue.inspect();
+			assert.deepEqual(job, fetchedJob);
+		});
+
+		it("should return null if there are no available jobs on the queue", async () => {
+			const queueKey = "this-example-sqlite-queue";
+			const anotherQueue = new SQLiteQueue({ queueKey, db });
+			await anotherQueue.flushAll();
+			const result = await anotherQueue.inspect();
+			assert.equal(result, null);
+		});
+	});
+
+	describe("taking a job", () => {
+		it("should move a job from the available queue to the processing queue", async () => {
+			const fetchedJob = await queue.take();
+			assert.deepEqual(job, fetchedJob);
+			const sqliteJob = fetchLatest(db, queue.queueKey, "processing");
+			if (!sqliteJob) {
+				throw new Error("Job not found in queue");
+			}
+			assert.deepEqual(sqliteJob, fetchedJob);
+		});
+	});
+
+	describe("completing a job", () => {
+		it("should move a job from the processing queue to the completed queue", async () => {
+			const processingJob = fetchLatest(db, queue.queueKey, "processing");
+			if (!processingJob) {
+				throw new Error("Job not found in queue");
+			}
+			await queue.complete(processingJob);
+			const stillProcessingJob = fetchLatest(db, queue.queueKey, "processing");
+			const completedJob = fetchLatest(db, queue.queueKey, "completed");
+			if (!completedJob) {
+				throw new Error("completedJob not found in queue");
+			}
+			assert.equal(stillProcessingJob, null);
+			assert.deepEqual(completedJob, processingJob);
+		});
+	});
+
+	describe("failing a job", () => {
+		it("should move a job from the processing queue to the failed queue", async () => {
+			await prepareJob(queue, db, "fail", "failed");
+		});
+	});
+
+	describe("releasing a job", () => {
+		it("should move a job from the processing queue to the available queue", async () => {
+			await prepareJob(queue, db, "release", "available");
+		});
+	});
+
+	describe("retrying a job", () => {
+		it("should move a job from the failed queue to the available queue", async () => {
+			await queue.flushAll();
+			await prepareJob(queue, db, "fail", "failed");
+			const failedJob = fetchLatest(db, queue.queueKey, "failed");
+			if (!failedJob) {
+				throw new Error("Job not found in queue");
+			}
+			await queue.retry(failedJob);
+			const stillFailedJob = fetchLatest(db, queue.queueKey, "failed");
+			const availableJob = fetchLatest(db, queue.queueKey, "available");
+			if (!availableJob) {
+				throw new Error("Jobs not found in queue");
+			}
+			assert.equal(stillFailedJob, null);
+			assert.deepEqual(availableJob, failedJob);
+		});
+	});
+
+	describe("flushing all jobs", () => {
+		it("should remove all jobs from all queues", async () => {
+			await queue.flushAll();
+			const available = fetchLatest(db, queue.queueKey, "available");
+			const processing = fetchLatest(db, queue.queueKey, "processing");
+			const completed = fetchLatest(db, queue.queueKey, "completed");
+			const failed = fetchLatest(db, queue.queueKey, "failed");
+			assert.equal(available, null);
+			assert.equal(processing, null);
+			assert.equal(completed, null);
+			assert.equal(failed, null);
+		});
+	});
+
+	describe("hooks", () => {
+		it("should allow the developer to add pre and post hooks to called actions", async () => {
+			const queueKey = "another-example-sqlite-queue";
+			let jobParam: Job | undefined;
+			const hookQueue = new SQLiteQueue({
+				queueKey,
+				db,
+				hooks: {
+					add: {
+						pre: async (job) => {
+							jobParam = job;
+							return Promise.resolve();
+						},
+					},
+				},
+			});
+			const hookJob = { name: "example-job" };
+			await hookQueue.add(hookJob);
+			assert.deepEqual(jobParam, hookJob);
+		});
+	});
+
+	describe("count", () => {
+		const queueKey = "another-example-sqlite-queue-count";
+		const countQueue = new SQLiteQueue({ queueKey, db });
+
+		beforeAll(async () => {
+			await countQueue.flushAll();
+			const initialCount = await countQueue.count("available");
+			assert.equal(initialCount, 0);
+			await countQueue.add({ name: "example-job" });
+		});
+
+		it("should return the number of jobs in a queue with a specific status", async () => {
+			const updatedCount = await countQueue.count("available");
+			assert.equal(updatedCount, 1);
+		});
+	});
+
+	describe("counts", () => {
+		it("should return the number of jobs in a queue, for each status", async () => {
+			await queue.flushAll();
+			await queue.add({ name: "example-job" });
+			const counts = await queue.counts();
+			assert.deepEqual(counts, {
+				available: 1,
+				processing: 0,
+				completed: 0,
+				failed: 0,
+			});
+			await queue.flushAll();
+		});
+	});
+
+	describe("disconnect", () => {
+		it("should close the sqlite database", async () => {
+			const anotherDb = createDb();
+			SQLiteQueue.migrate(anotherDb);
+			const anotherQueue = new SQLiteQueue({
+				queueKey: "other-sqlite-queue",
+				db: anotherDb,
+			});
+			await anotherQueue.disconnect();
+			assert.throws(() => anotherDb.prepare("SELECT 1").get());
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Adds `SQLiteQueue`, a SQLite-backed implementation of the same public API as `Queue`/`PostgresQueue` (`add`/`take`/`complete`/`fail`/`release`/`retry`/`inspect`/`count`/`counts`/`flushAll`/`disconnect`), so it's a drop-in alternative wherever `Queue` is used today, backed by [better-sqlite3](https://github.com/WiseLibs/better-sqlite3).
- `Worker` needed no changes — it was already backend-agnostic, so it works unchanged with `Queue` (Redis), `PostgresQueue`, or `SQLiteQueue`.
- Adds a `SQLiteQueue.migrate(db)` helper for idempotent schema setup (single `job_queue_jobs` table, keyed by `queue_key`/`status`).
- `take()` claims a job inside an immediate write transaction (`BEGIN IMMEDIATE`) — SQLite only ever allows one writer, so this is the single-writer equivalent of Postgres's `FOR UPDATE SKIP LOCKED`, guaranteeing no two workers are handed the same job.
- WAL mode + `busy_timeout` are set on construction, so multiple processes on the same host can share one SQLite file for concurrent reads/writes without a database server.
- No CI service changes needed — SQLite is embedded, so the test suite runs entirely against an in-memory database.
- README documents the new SQLite usage path, including the caveat that (unlike Redis/Postgres) all queue/worker processes must share the same local disk.

## Test plan
- [x] `npm run build` (tsc) — clean
- [x] `npm run lint` (biome) — clean on all changed files
- [x] `npm t` — 69/69 tests pass locally (54 existing Redis/Postgres tests unaffected, 15 new `SQLiteQueue` tests) against local Redis + Postgres + in-memory SQLite
- [x] `npm run size` — well under the 10kB brotli budget
- [x] `npm run lint:package` (publint) — clean
- [x] `npm run test:e2e` — CommonJS and ESM build smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)