### PR TITLE
Add runnable examples demonstrating job-queue usage

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,36 @@
+# Examples
+
+Runnable examples of [`@anephenix/job-queue`](https://github.com/anephenix/job-queue)
+in use. Each one is a self-contained npm project — `cd` into it, run
+`npm install`, and follow its README.
+
+| Example | Backend | What it shows |
+| --- | --- | --- |
+| [mp4-to-hls](./mp4-to-hls) | SQLite | Transcoding an uploaded video into HLS (`.m3u8` + `.ts`) with ffmpeg |
+| [email-sending](./email-sending) | Redis | Sending email in the background with nodemailer |
+| [csv-import](./csv-import) | Postgres | Streaming a CSV file and bulk-inserting its rows |
+| [image-thumbnails](./image-thumbnails) | SQLite | Generating resized image thumbnails with sharp — the fastest one to try |
+| [webhook-delivery](./webhook-delivery) | SQLite | Retrying failed HTTP deliveries with backoff, using the `fail`/`retry` hooks |
+| [pdf-report-generation](./pdf-report-generation) | SQLite | Rendering a PDF invoice with pdfkit |
+
+### Which one to start with
+
+If you just want to see a job go from queued to completed as quickly as
+possible, start with **image-thumbnails** — it needs no external
+services and finishes in well under a second. **webhook-delivery** is
+the one to read if you want to see the queue's hooks used for something
+beyond logging (retry-with-backoff). The others each pair a use case
+with the backend (`Queue`/Redis, `PostgresQueue`, `SQLiteQueue`) it
+makes the most sense to try alongside.
+
+### Common shape
+
+Every example follows the same layout:
+
+-   `src/queue.ts` — creates the queue (and runs any needed migrations)
+-   `src/worker.ts` — a `Worker` subclass that does the actual work
+-   `src/add-job.ts` — a CLI script to queue a job (`npm run add-job -- ...`)
+-   `src/start-worker.ts` — starts the worker (`npm run worker`)
+
+Each example's own README has the exact prerequisites and commands to
+run it.

--- a/examples/csv-import/.gitignore
+++ b/examples/csv-import/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/csv-import/README.md
+++ b/examples/csv-import/README.md
@@ -1,0 +1,72 @@
+# Example: CSV import into Postgres
+
+This example shows how to use [`@anephenix/job-queue`](https://github.com/anephenix/job-queue)
+to import a CSV file into Postgres in the background rather than blocking
+a request while a (potentially large) file is parsed and inserted. It
+uses the Postgres-backed `PostgresQueue`.
+
+### How it works
+
+-   `src/postgres.ts` creates a `pg` connection pool.
+-   `src/schema.ts` creates the `imported_contacts` table that rows are
+    imported into.
+-   `src/queue.ts` creates a `PostgresQueue` called `csv-import`, and
+    runs both table migrations on startup.
+-   `src/worker.ts` defines a `Worker` subclass that streams the CSV file
+    named in the job (rather than loading it fully into memory) and
+    inserts its rows into `imported_contacts` in batches.
+-   `src/add-job.ts` is a small CLI script that queues a CSV file for
+    import.
+-   `src/start-worker.ts` starts the worker, which polls the queue and
+    processes jobs as they arrive.
+
+The CSV is expected to have `name` and `email` columns — see
+`sample/contacts.csv` for the format.
+
+### Prerequisites
+
+-   Node.js
+-   Postgres running locally on the default port (5432), e.g.:
+
+    ```shell
+    docker run -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres
+    ```
+
+    The example connects as user `postgres`, password `postgres`,
+    database `postgres` by default — override with the `POSTGRES_HOST`,
+    `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD` and
+    `POSTGRES_DB` environment variables if needed.
+
+### Setup
+
+From this directory:
+
+```shell
+npm install
+```
+
+### Usage
+
+1.  Queue the sample CSV for import:
+
+    ```shell
+    npm run add-job -- sample/contacts.csv
+    ```
+
+2.  In another terminal, start the worker to process queued jobs:
+
+    ```shell
+    npm run worker
+    ```
+
+The worker will pick up the job, stream and parse the file, and insert
+its rows into the `imported_contacts` table. You can check the results
+with `psql`:
+
+```shell
+psql postgresql://postgres:postgres@localhost:5432/postgres \
+  -c "SELECT * FROM imported_contacts;"
+```
+
+Queue up as many CSV files as you like with `npm run add-job -- <path>`
+— the worker will keep polling and process them one after another.

--- a/examples/csv-import/package.json
+++ b/examples/csv-import/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "csv-import-example",
+	"version": "1.0.0",
+	"description": "Example: import a CSV file into Postgres in the background using @anephenix/job-queue and PostgresQueue",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"worker": "tsx src/start-worker.ts",
+		"add-job": "tsx src/add-job.ts"
+	},
+	"dependencies": {
+		"@anephenix/job-queue": "file:../..",
+		"csv-parse": "^7.0.2"
+	},
+	"devDependencies": {
+		"@types/node": "^26.0.0",
+		"@types/pg": "^8.21.0",
+		"tsx": "^4.19.4",
+		"typescript": "^7.0.2"
+	}
+}

--- a/examples/csv-import/sample/contacts.csv
+++ b/examples/csv-import/sample/contacts.csv
@@ -1,0 +1,6 @@
+name,email
+Ada Lovelace,ada@example.com
+Alan Turing,alan@example.com
+Grace Hopper,grace@example.com
+Katherine Johnson,katherine@example.com
+Margaret Hamilton,margaret@example.com

--- a/examples/csv-import/src/add-job.ts
+++ b/examples/csv-import/src/add-job.ts
@@ -1,0 +1,23 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import csvImportQueue from "./queue.ts";
+
+const filePath = process.argv[2];
+
+if (!filePath) {
+	console.error("Usage: npm run add-job -- <path-to-csv-file>");
+	process.exit(1);
+}
+
+if (!existsSync(filePath)) {
+	console.error(`File not found: ${filePath}`);
+	process.exit(1);
+}
+
+await csvImportQueue.add({
+	name: "csv-import",
+	data: { filePath: path.resolve(filePath) },
+});
+
+console.log(`Queued ${filePath} for import.`);
+await csvImportQueue.disconnect();

--- a/examples/csv-import/src/postgres.ts
+++ b/examples/csv-import/src/postgres.ts
@@ -1,0 +1,16 @@
+// Dependencies
+import { Pool, type PoolConfig } from "pg";
+
+const poolConfig: PoolConfig = {
+	host: process.env.POSTGRES_HOST || "localhost",
+	port: process.env.POSTGRES_PORT
+		? Number.parseInt(process.env.POSTGRES_PORT, 10)
+		: 5432,
+	user: process.env.POSTGRES_USER || "postgres",
+	password: process.env.POSTGRES_PASSWORD || "postgres",
+	database: process.env.POSTGRES_DB || "postgres",
+};
+
+const pool = new Pool(poolConfig);
+
+export default pool;

--- a/examples/csv-import/src/queue.ts
+++ b/examples/csv-import/src/queue.ts
@@ -1,0 +1,22 @@
+import { type Hooks, PostgresQueue } from "@anephenix/job-queue";
+import pool from "./postgres.ts";
+import { ensureContactsTable } from "./schema.ts";
+
+// Creates the job_queue_jobs and imported_contacts tables if they don't
+// already exist. Safe to call every time the process starts.
+await PostgresQueue.migrate(pool);
+await ensureContactsTable(pool);
+
+type QueueOptions = {
+	queueKey: string;
+	pg: typeof pool;
+	hooks: Partial<Hooks>;
+};
+const queueOptions: QueueOptions = {
+	queueKey: "csv-import",
+	pg: pool,
+	hooks: {},
+};
+const csvImportQueue = new PostgresQueue(queueOptions);
+
+export default csvImportQueue;

--- a/examples/csv-import/src/schema.ts
+++ b/examples/csv-import/src/schema.ts
@@ -1,0 +1,16 @@
+import type { Pool } from "pg";
+
+// The table that imported CSV rows are written into. Separate from the
+// job_queue_jobs table that PostgresQueue.migrate() creates.
+async function ensureContactsTable(pool: Pool): Promise<void> {
+	await pool.query(`
+		CREATE TABLE IF NOT EXISTS imported_contacts (
+			id BIGSERIAL PRIMARY KEY,
+			name TEXT NOT NULL,
+			email TEXT NOT NULL,
+			imported_at TIMESTAMPTZ NOT NULL DEFAULT now()
+		)
+	`);
+}
+
+export { ensureContactsTable };

--- a/examples/csv-import/src/start-worker.ts
+++ b/examples/csv-import/src/start-worker.ts
@@ -1,0 +1,12 @@
+import csvImportWorker from "./worker.ts";
+
+console.log("CSV import worker started, polling for jobs...");
+console.log("Press Ctrl+C to stop.");
+
+process.on("SIGINT", async () => {
+	console.log("\nStopping worker...");
+	await csvImportWorker.stop();
+	process.exit(0);
+});
+
+await csvImportWorker.start();

--- a/examples/csv-import/src/worker.ts
+++ b/examples/csv-import/src/worker.ts
@@ -1,0 +1,73 @@
+import { createReadStream } from "node:fs";
+import { type Job, Worker } from "@anephenix/job-queue";
+import { parse } from "csv-parse";
+import pool from "./postgres.ts";
+import csvImportQueue from "./queue.ts";
+
+type CSVImportJob = Job & {
+	data: {
+		filePath: string;
+	};
+};
+
+type ContactRow = { name: string; email: string };
+
+// Rows are inserted in batches rather than one at a time, so importing a
+// large CSV doesn't mean a round trip to Postgres per row.
+const BATCH_SIZE = 500;
+
+async function insertBatch(rows: ContactRow[]): Promise<void> {
+	if (rows.length === 0) return;
+	const values: string[] = [];
+	const params: string[] = [];
+	rows.forEach((row, index) => {
+		const offset = index * 2;
+		values.push(`($${offset + 1}, $${offset + 2})`);
+		params.push(row.name, row.email);
+	});
+	await pool.query(
+		`INSERT INTO imported_contacts (name, email) VALUES ${values.join(", ")}`,
+		params,
+	);
+}
+
+class CSVImportWorker extends Worker {
+	async processJob(job: Job): Promise<void> {
+		this.status = "processing";
+		const { filePath } = (job as CSVImportJob).data;
+
+		try {
+			// Streamed rather than read fully into memory first, so this
+			// scales to CSV files much larger than available RAM.
+			const parser = createReadStream(filePath).pipe(
+				parse({ columns: true, trim: true }),
+			);
+
+			let batch: ContactRow[] = [];
+			let total = 0;
+
+			for await (const record of parser as AsyncIterable<
+				Record<string, string>
+			>) {
+				batch.push({ name: record.name, email: record.email });
+				if (batch.length >= BATCH_SIZE) {
+					await insertBatch(batch);
+					total += batch.length;
+					batch = [];
+				}
+			}
+			await insertBatch(batch);
+			total += batch.length;
+
+			console.log(`Imported ${total} rows from ${filePath}`);
+			await this.completeJob(job);
+		} catch (err) {
+			console.error(`Error importing ${filePath}:`, err);
+			await this.failJob(job);
+		}
+	}
+}
+
+const csvImportWorker = new CSVImportWorker(csvImportQueue);
+
+export default csvImportWorker;

--- a/examples/csv-import/tsconfig.json
+++ b/examples/csv-import/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"esModuleInterop": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"]
+}

--- a/examples/email-sending/.gitignore
+++ b/examples/email-sending/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/email-sending/README.md
+++ b/examples/email-sending/README.md
@@ -1,0 +1,66 @@
+# Example: Background email sending
+
+This example shows how to use [`@anephenix/job-queue`](https://github.com/anephenix/job-queue)
+to send email in the background rather than as part of a request/response
+cycle — the classic job queue use case. It uses the Redis-backed `Queue`
+and [nodemailer](https://nodemailer.com/).
+
+Emails are sent through an [Ethereal](https://ethereal.email) test
+account, created automatically the first time the worker runs, so you can
+try this out without any real SMTP credentials. Nothing lands in a real
+inbox — instead, the worker logs a preview URL for each email it sends,
+which you can open in a browser to see it.
+
+### How it works
+
+-   `src/redis.ts` creates and connects a Redis client.
+-   `src/queue.ts` creates a `Queue` called `email`, backed by Redis.
+-   `src/mailer.ts` lazily creates a nodemailer transporter using a fresh
+    Ethereal test account.
+-   `src/worker.ts` defines a `Worker` subclass that sends each queued
+    job as an email.
+-   `src/add-job.ts` is a small CLI script that queues an email.
+-   `src/start-worker.ts` starts the worker, which polls the queue and
+    processes jobs as they arrive.
+
+### Prerequisites
+
+-   Node.js
+-   Redis running locally on the default port (6379), e.g.:
+
+    ```shell
+    docker run -p 6379:6379 redis
+    ```
+
+-   An internet connection (needed to create the Ethereal test account
+    and send through `smtp.ethereal.email`)
+
+### Setup
+
+From this directory:
+
+```shell
+npm install
+```
+
+### Usage
+
+1.  Queue an email:
+
+    ```shell
+    npm run add-job -- someone@example.com "Hello" "This is a test email sent via a job queue."
+    ```
+
+2.  In another terminal, start the worker to process queued jobs:
+
+    ```shell
+    npm run worker
+    ```
+
+The worker will pick up the job, send it via Ethereal, and print a
+preview URL, e.g. `Preview URL: https://ethereal.email/message/xxxxx`.
+Open that link to see the email as it would have looked to the
+recipient.
+
+Queue up as many emails as you like with `npm run add-job -- ...` — the
+worker will keep polling and process them one after another.

--- a/examples/email-sending/package.json
+++ b/examples/email-sending/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "email-sending-example",
+	"version": "1.0.0",
+	"description": "Example: send emails in the background using @anephenix/job-queue, Redis and nodemailer",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"worker": "tsx src/start-worker.ts",
+		"add-job": "tsx src/add-job.ts"
+	},
+	"dependencies": {
+		"@anephenix/job-queue": "file:../..",
+		"nodemailer": "^9.0.5"
+	},
+	"devDependencies": {
+		"@types/nodemailer": "^8.0.1",
+		"@types/node": "^26.0.0",
+		"tsx": "^4.19.4",
+		"typescript": "^7.0.2"
+	}
+}

--- a/examples/email-sending/src/add-job.ts
+++ b/examples/email-sending/src/add-job.ts
@@ -1,0 +1,17 @@
+import emailQueue from "./queue.ts";
+
+const [to, subject, ...rest] = process.argv.slice(2);
+const text = rest.join(" ");
+
+if (!to || !subject || !text) {
+	console.error('Usage: npm run add-job -- <to> "<subject>" "<body text>"');
+	process.exit(1);
+}
+
+await emailQueue.add({
+	name: "send-email",
+	data: { to, subject, text },
+});
+
+console.log(`Queued email to ${to}: ${subject}`);
+await emailQueue.disconnect();

--- a/examples/email-sending/src/mailer.ts
+++ b/examples/email-sending/src/mailer.ts
@@ -1,0 +1,30 @@
+import nodemailer, { type Transporter } from "nodemailer";
+
+let transporterPromise: Promise<Transporter> | null = null;
+
+/*
+ * Uses an Ethereal (https://ethereal.email) test account, created on the
+ * fly, so this example can send email without needing a real SMTP server
+ * or credentials. Nothing is delivered to a real inbox - each "sent"
+ * email can be viewed via the preview URL that the worker logs to the
+ * console.
+ */
+function getTransporter(): Promise<Transporter> {
+	if (!transporterPromise) {
+		transporterPromise = (async () => {
+			const testAccount = await nodemailer.createTestAccount();
+			return nodemailer.createTransport({
+				host: "smtp.ethereal.email",
+				port: 587,
+				secure: false,
+				auth: {
+					user: testAccount.user,
+					pass: testAccount.pass,
+				},
+			});
+		})();
+	}
+	return transporterPromise;
+}
+
+export default getTransporter;

--- a/examples/email-sending/src/queue.ts
+++ b/examples/email-sending/src/queue.ts
@@ -1,0 +1,12 @@
+import { type Hooks, Queue } from "@anephenix/job-queue";
+import redis from "./redis.ts";
+
+type QueueOptions = {
+	queueKey: string;
+	redis: typeof redis;
+	hooks: Partial<Hooks>;
+};
+const queueOptions: QueueOptions = { queueKey: "email", redis, hooks: {} };
+const emailQueue = new Queue(queueOptions);
+
+export default emailQueue;

--- a/examples/email-sending/src/redis.ts
+++ b/examples/email-sending/src/redis.ts
@@ -1,0 +1,6 @@
+import { createClient, type RedisClientType } from "redis";
+
+const redis: RedisClientType = createClient();
+await redis.connect();
+
+export default redis;

--- a/examples/email-sending/src/start-worker.ts
+++ b/examples/email-sending/src/start-worker.ts
@@ -1,0 +1,12 @@
+import emailWorker from "./worker.ts";
+
+console.log("Email worker started, polling for jobs...");
+console.log("Press Ctrl+C to stop.");
+
+process.on("SIGINT", async () => {
+	console.log("\nStopping worker...");
+	await emailWorker.stop();
+	process.exit(0);
+});
+
+await emailWorker.start();

--- a/examples/email-sending/src/worker.ts
+++ b/examples/email-sending/src/worker.ts
@@ -1,0 +1,39 @@
+import { type Job, Worker } from "@anephenix/job-queue";
+import nodemailer from "nodemailer";
+import getTransporter from "./mailer.ts";
+import emailQueue from "./queue.ts";
+
+type EmailJob = Job & {
+	data: {
+		to: string;
+		subject: string;
+		text: string;
+	};
+};
+
+class EmailWorker extends Worker {
+	async processJob(job: Job): Promise<void> {
+		this.status = "processing";
+		const { to, subject, text } = (job as EmailJob).data;
+
+		try {
+			const transporter = await getTransporter();
+			const info = await transporter.sendMail({
+				from: '"Job Queue Example" <example@job-queue.local>',
+				to,
+				subject,
+				text,
+			});
+			console.log(`Sent email to ${to}: ${subject}`);
+			console.log(`Preview URL: ${nodemailer.getTestMessageUrl(info)}`);
+			await this.completeJob(job);
+		} catch (err) {
+			console.error(`Error sending email to ${to}:`, err);
+			await this.failJob(job);
+		}
+	}
+}
+
+const emailWorker = new EmailWorker(emailQueue);
+
+export default emailWorker;

--- a/examples/email-sending/tsconfig.json
+++ b/examples/email-sending/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"esModuleInterop": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"]
+}

--- a/examples/image-thumbnails/.gitignore
+++ b/examples/image-thumbnails/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+job-queue.db
+job-queue.db-shm
+job-queue.db-wal
+output/*
+!output/.gitkeep
+input/*
+!input/.gitkeep

--- a/examples/image-thumbnails/README.md
+++ b/examples/image-thumbnails/README.md
@@ -1,0 +1,57 @@
+# Example: Image thumbnail generation
+
+This example shows how to use [`@anephenix/job-queue`](https://github.com/anephenix/job-queue)
+to generate image thumbnails in the background using
+[sharp](https://sharp.pixelplumbing.com/). It's a good "first job queue"
+example — it uses `SQLiteQueue`, so there's no need to run Redis or
+Postgres, and processing an image is quick, so you'll see a job go from
+queued to completed in well under a second.
+
+### How it works
+
+-   `src/queue.ts` creates a `SQLiteQueue` called `image-thumbnails`. The
+    queue is stored in a local `job-queue.db` file.
+-   `src/worker.ts` defines a `Worker` subclass that, for each job,
+    generates three resized `.webp` versions of the input image (small,
+    medium, large).
+-   `src/add-job.ts` is a small CLI script that adds a job to the queue
+    for a given image file.
+-   `src/start-worker.ts` starts the worker, which polls the queue and
+    processes jobs as they arrive.
+
+### Prerequisites
+
+-   Node.js
+
+That's it — `sharp` ships prebuilt binaries, so no separate image
+library needs to be installed.
+
+### Setup
+
+From this directory:
+
+```shell
+npm install
+```
+
+### Usage
+
+1.  Put an image file somewhere on disk (the `input/` folder is a handy
+    place to keep it), then queue it for thumbnail generation:
+
+    ```shell
+    npm run add-job -- input/my-photo.jpg
+    ```
+
+2.  In another terminal, start the worker to process queued jobs:
+
+    ```shell
+    npm run worker
+    ```
+
+The worker will pick up the job and write `small.webp`, `medium.webp`
+and `large.webp` (200px, 500px and 1000px wide respectively, aspect
+ratio preserved) to `output/my-photo/`.
+
+Queue up as many images as you like with `npm run add-job -- <path>` —
+the worker will keep polling and process them one after another.

--- a/examples/image-thumbnails/package.json
+++ b/examples/image-thumbnails/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "image-thumbnails-example",
+	"version": "1.0.0",
+	"description": "Example: generate image thumbnails in the background using @anephenix/job-queue and sharp",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"worker": "tsx src/start-worker.ts",
+		"add-job": "tsx src/add-job.ts"
+	},
+	"dependencies": {
+		"@anephenix/job-queue": "file:../..",
+		"better-sqlite3": "^13.0.3",
+		"sharp": "^0.35.3"
+	},
+	"devDependencies": {
+		"@types/better-sqlite3": "^9.6.0",
+		"@types/node": "^26.0.0",
+		"tsx": "^4.19.4",
+		"typescript": "^7.0.2"
+	}
+}

--- a/examples/image-thumbnails/src/add-job.ts
+++ b/examples/image-thumbnails/src/add-job.ts
@@ -1,0 +1,28 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import thumbnailQueue from "./queue.ts";
+
+const inputPath = process.argv[2];
+
+if (!inputPath) {
+	console.error("Usage: npm run add-job -- <path-to-image-file>");
+	process.exit(1);
+}
+
+if (!existsSync(inputPath)) {
+	console.error(`File not found: ${inputPath}`);
+	process.exit(1);
+}
+
+const name = path.basename(inputPath, path.extname(inputPath));
+const outputDir = path.join("output", name);
+
+await thumbnailQueue.add({
+	name: "generate-thumbnails",
+	data: { inputPath, outputDir },
+});
+
+console.log(
+	`Queued ${inputPath} for thumbnail generation. Output will be written to ${outputDir}/`,
+);
+await thumbnailQueue.disconnect();

--- a/examples/image-thumbnails/src/queue.ts
+++ b/examples/image-thumbnails/src/queue.ts
@@ -1,0 +1,16 @@
+import { type Hooks, SQLiteQueue } from "@anephenix/job-queue";
+import db from "./sqlite.ts";
+
+// Creates the job_queue_jobs table if it doesn't already exist.
+// Safe to call every time the process starts.
+SQLiteQueue.migrate(db);
+
+type QueueOptions = { queueKey: string; db: typeof db; hooks: Partial<Hooks> };
+const queueOptions: QueueOptions = {
+	queueKey: "image-thumbnails",
+	db,
+	hooks: {},
+};
+const thumbnailQueue = new SQLiteQueue(queueOptions);
+
+export default thumbnailQueue;

--- a/examples/image-thumbnails/src/sqlite.ts
+++ b/examples/image-thumbnails/src/sqlite.ts
@@ -1,0 +1,7 @@
+// A local SQLite database file is used so that this example can be run
+// without needing to install and run Redis or Postgres.
+import Database from "better-sqlite3";
+
+const db = new Database("./job-queue.db");
+
+export default db;

--- a/examples/image-thumbnails/src/start-worker.ts
+++ b/examples/image-thumbnails/src/start-worker.ts
@@ -1,0 +1,12 @@
+import thumbnailWorker from "./worker.ts";
+
+console.log("Thumbnail worker started, polling for jobs...");
+console.log("Press Ctrl+C to stop.");
+
+process.on("SIGINT", async () => {
+	console.log("\nStopping worker...");
+	await thumbnailWorker.stop();
+	process.exit(0);
+});
+
+await thumbnailWorker.start();

--- a/examples/image-thumbnails/src/worker.ts
+++ b/examples/image-thumbnails/src/worker.ts
@@ -1,0 +1,54 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { type Job, Worker } from "@anephenix/job-queue";
+import sharp from "sharp";
+import thumbnailQueue from "./queue.ts";
+
+type ThumbnailJob = Job & {
+	data: {
+		inputPath: string;
+		outputDir: string;
+	};
+};
+
+const SIZES = [
+	{ name: "small", width: 200 },
+	{ name: "medium", width: 500 },
+	{ name: "large", width: 1000 },
+];
+
+async function generateThumbnails(
+	inputPath: string,
+	outputDir: string,
+): Promise<void> {
+	await mkdir(outputDir, { recursive: true });
+	await Promise.all(
+		SIZES.map(({ name, width }) =>
+			sharp(inputPath)
+				.resize({ width, withoutEnlargement: true })
+				.webp()
+				.toFile(path.join(outputDir, `${name}.webp`)),
+		),
+	);
+}
+
+class ThumbnailWorker extends Worker {
+	async processJob(job: Job): Promise<void> {
+		this.status = "processing";
+		const { inputPath, outputDir } = (job as ThumbnailJob).data;
+
+		try {
+			console.log(`Generating thumbnails for ${inputPath} -> ${outputDir}`);
+			await generateThumbnails(inputPath, outputDir);
+			console.log(`Finished generating thumbnails for ${inputPath}`);
+			await this.completeJob(job);
+		} catch (err) {
+			console.error(`Error generating thumbnails for ${inputPath}:`, err);
+			await this.failJob(job);
+		}
+	}
+}
+
+const thumbnailWorker = new ThumbnailWorker(thumbnailQueue);
+
+export default thumbnailWorker;

--- a/examples/image-thumbnails/tsconfig.json
+++ b/examples/image-thumbnails/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"esModuleInterop": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"]
+}

--- a/examples/mp4-to-hls/.gitignore
+++ b/examples/mp4-to-hls/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+job-queue.db
+job-queue.db-shm
+job-queue.db-wal
+output/*
+!output/.gitkeep
+input/*
+!input/.gitkeep

--- a/examples/mp4-to-hls/README.md
+++ b/examples/mp4-to-hls/README.md
@@ -1,0 +1,56 @@
+# Example: MP4 to HLS transcoder
+
+This example shows how to use [`@anephenix/job-queue`](https://github.com/anephenix/job-queue)
+to build a background job that transcodes an `.mp4` video file into an
+Apple HTTP Live Streaming (HLS) rendition — a `.m3u8` playlist plus a set
+of `.ts` segment files — using [ffmpeg](https://ffmpeg.org/).
+
+It uses `SQLiteQueue`, so there's no need to run Redis or Postgres to try
+it out; the queue is stored in a local `job-queue.db` file.
+
+### How it works
+
+-   `src/queue.ts` creates a `SQLiteQueue` called `hls-transcode`.
+-   `src/worker.ts` defines a `Worker` subclass that, for each job, shells
+    out to `ffmpeg` to convert the input `.mp4` file into HLS output.
+-   `src/add-job.ts` is a small CLI script that adds a job to the queue
+    for a given `.mp4` file.
+-   `src/start-worker.ts` starts the worker, which polls the queue and
+    processes jobs as they arrive.
+
+### Prerequisites
+
+-   Node.js
+-   [ffmpeg](https://ffmpeg.org/download.html) installed and available on
+    your `PATH` (e.g. `brew install ffmpeg` on macOS)
+
+### Setup
+
+From this directory:
+
+```shell
+npm install
+```
+
+### Usage
+
+1.  Put an `.mp4` file somewhere on disk (the `input/` folder is a handy
+    place to keep it), then queue it for transcoding:
+
+    ```shell
+    npm run add-job -- input/my-video.mp4
+    ```
+
+2.  In another terminal, start the worker to process queued jobs:
+
+    ```shell
+    npm run worker
+    ```
+
+The worker will pick up the job, run ffmpeg, and write `index.m3u8` and
+the `.ts` segment files to `output/my-video/`. You can serve that folder
+with any static file server and play `index.m3u8` in an HLS-capable
+player (e.g. Safari, or `ffplay output/my-video/index.m3u8`).
+
+Queue up as many files as you like with `npm run add-job -- <path>` —
+the worker will keep polling and process them one after another.

--- a/examples/mp4-to-hls/package.json
+++ b/examples/mp4-to-hls/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "mp4-to-hls-example",
+	"version": "1.0.0",
+	"description": "Example: transcode an MP4 file into an Apple HTTP Live Streaming (HLS) rendition using @anephenix/job-queue and ffmpeg",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"worker": "tsx src/start-worker.ts",
+		"add-job": "tsx src/add-job.ts"
+	},
+	"dependencies": {
+		"@anephenix/job-queue": "file:../..",
+		"better-sqlite3": "^13.0.3"
+	},
+	"devDependencies": {
+		"@types/better-sqlite3": "^9.6.0",
+		"@types/node": "^26.0.0",
+		"tsx": "^4.19.4",
+		"typescript": "^7.0.2"
+	}
+}

--- a/examples/mp4-to-hls/src/add-job.ts
+++ b/examples/mp4-to-hls/src/add-job.ts
@@ -1,0 +1,28 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import transcodeQueue from "./queue.ts";
+
+const inputPath = process.argv[2];
+
+if (!inputPath) {
+	console.error("Usage: npm run add-job -- <path-to-mp4-file>");
+	process.exit(1);
+}
+
+if (!existsSync(inputPath)) {
+	console.error(`File not found: ${inputPath}`);
+	process.exit(1);
+}
+
+const name = path.basename(inputPath, path.extname(inputPath));
+const outputDir = path.join("output", name);
+
+await transcodeQueue.add({
+	name: "hls-transcode",
+	data: { inputPath, outputDir },
+});
+
+console.log(
+	`Queued ${inputPath} for transcoding. Output will be written to ${outputDir}/`,
+);
+await transcodeQueue.disconnect();

--- a/examples/mp4-to-hls/src/queue.ts
+++ b/examples/mp4-to-hls/src/queue.ts
@@ -1,0 +1,12 @@
+import { type Hooks, SQLiteQueue } from "@anephenix/job-queue";
+import db from "./sqlite.ts";
+
+// Creates the job_queue_jobs table if it doesn't already exist.
+// Safe to call every time the process starts.
+SQLiteQueue.migrate(db);
+
+type QueueOptions = { queueKey: string; db: typeof db; hooks: Partial<Hooks> };
+const queueOptions: QueueOptions = { queueKey: "hls-transcode", db, hooks: {} };
+const transcodeQueue = new SQLiteQueue(queueOptions);
+
+export default transcodeQueue;

--- a/examples/mp4-to-hls/src/sqlite.ts
+++ b/examples/mp4-to-hls/src/sqlite.ts
@@ -1,0 +1,7 @@
+// A local SQLite database file is used so that this example can be run
+// without needing to install and run Redis or Postgres.
+import Database from "better-sqlite3";
+
+const db = new Database("./job-queue.db");
+
+export default db;

--- a/examples/mp4-to-hls/src/start-worker.ts
+++ b/examples/mp4-to-hls/src/start-worker.ts
@@ -1,0 +1,12 @@
+import hlsTranscodeWorker from "./worker.ts";
+
+console.log("HLS transcode worker started, polling for jobs...");
+console.log("Press Ctrl+C to stop.");
+
+process.on("SIGINT", async () => {
+	console.log("\nStopping worker...");
+	await hlsTranscodeWorker.stop();
+	process.exit(0);
+});
+
+await hlsTranscodeWorker.start();

--- a/examples/mp4-to-hls/src/worker.ts
+++ b/examples/mp4-to-hls/src/worker.ts
@@ -1,0 +1,79 @@
+import { spawn } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { type Job, Worker } from "@anephenix/job-queue";
+import transcodeQueue from "./queue.ts";
+
+type TranscodeJob = Job & {
+	data: {
+		inputPath: string;
+		outputDir: string;
+	};
+};
+
+/*
+ * Runs ffmpeg as a child process, converting the input mp4 file into an
+ * HLS rendition (a .m3u8 playlist plus a series of .ts segment files)
+ * inside outputDir. Requires ffmpeg to be installed and on the PATH.
+ */
+function runFfmpeg(inputPath: string, outputDir: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const playlistPath = path.join(outputDir, "index.m3u8");
+		const segmentPath = path.join(outputDir, "segment%03d.ts");
+
+		const ffmpeg = spawn("ffmpeg", [
+			"-y",
+			"-i",
+			inputPath,
+			"-codec:",
+			"copy",
+			"-start_number",
+			"0",
+			"-hls_time",
+			"10",
+			"-hls_list_size",
+			"0",
+			"-hls_segment_filename",
+			segmentPath,
+			"-f",
+			"hls",
+			playlistPath,
+		]);
+
+		let stderr = "";
+		ffmpeg.stderr.on("data", (chunk) => {
+			stderr += chunk.toString();
+		});
+
+		ffmpeg.on("error", reject);
+		ffmpeg.on("close", (code) => {
+			if (code === 0) {
+				resolve();
+			} else {
+				reject(new Error(`ffmpeg exited with code ${code}\n${stderr}`));
+			}
+		});
+	});
+}
+
+class HLSTranscodeWorker extends Worker {
+	async processJob(job: Job): Promise<void> {
+		this.status = "processing";
+		const { inputPath, outputDir } = (job as TranscodeJob).data;
+
+		try {
+			console.log(`Transcoding ${inputPath} -> ${outputDir}`);
+			await mkdir(outputDir, { recursive: true });
+			await runFfmpeg(inputPath, outputDir);
+			console.log(`Finished transcoding ${inputPath}`);
+			await this.completeJob(job);
+		} catch (err) {
+			console.error(`Error transcoding ${inputPath}:`, err);
+			await this.failJob(job);
+		}
+	}
+}
+
+const hlsTranscodeWorker = new HLSTranscodeWorker(transcodeQueue);
+
+export default hlsTranscodeWorker;

--- a/examples/mp4-to-hls/tsconfig.json
+++ b/examples/mp4-to-hls/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"esModuleInterop": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"]
+}

--- a/examples/pdf-report-generation/.gitignore
+++ b/examples/pdf-report-generation/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+job-queue.db
+job-queue.db-shm
+job-queue.db-wal
+output/*
+!output/.gitkeep

--- a/examples/pdf-report-generation/README.md
+++ b/examples/pdf-report-generation/README.md
@@ -1,0 +1,69 @@
+# Example: PDF report generation
+
+This example shows how to use [`@anephenix/job-queue`](https://github.com/anephenix/job-queue)
+to render a PDF report in the background rather than blocking a web
+request while the document is generated. It uses
+[pdfkit](https://pdfkit.org/) and `SQLiteQueue`, so there's no need to
+run Redis or Postgres, and nothing beyond `npm install` is needed to
+try it out (no headless browser to download, unlike an HTML-to-PDF
+approach such as puppeteer).
+
+The sample report is a simple invoice, but the same shape applies to
+any CPU-bound "take some data, produce a document" job — statements,
+certificates, exports, and so on.
+
+### How it works
+
+-   `src/queue.ts` creates a `SQLiteQueue` called `pdf-report-generation`.
+-   `src/worker.ts` defines a `Worker` subclass that reads the JSON
+    input named in the job, lays out an invoice (header, line item
+    table, grand total, with pagination if it runs long) with `pdfkit`,
+    and writes it to the output path named in the job.
+-   `src/add-job.ts` is a small CLI script that queues a report for
+    generation from a JSON file.
+-   `src/start-worker.ts` starts the worker, which polls the queue and
+    processes jobs as they arrive.
+
+The input JSON is expected to look like `sample/invoice.json`:
+
+```json
+{
+	"title": "Invoice #1042",
+	"customer": "Acme Corp",
+	"items": [
+		{ "description": "Consulting services", "quantity": 10, "unitPrice": 150 }
+	]
+}
+```
+
+### Prerequisites
+
+-   Node.js
+
+### Setup
+
+From this directory:
+
+```shell
+npm install
+```
+
+### Usage
+
+1.  Queue the sample invoice for rendering:
+
+    ```shell
+    npm run add-job -- sample/invoice.json
+    ```
+
+2.  In another terminal, start the worker to process queued jobs:
+
+    ```shell
+    npm run worker
+    ```
+
+The worker will pick up the job and write `output/invoice.pdf`,
+containing the invoice header, an itemised table and the grand total.
+
+Queue up as many reports as you like with `npm run add-job -- <path>` —
+the worker will keep polling and process them one after another.

--- a/examples/pdf-report-generation/package.json
+++ b/examples/pdf-report-generation/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "pdf-report-generation-example",
+	"version": "1.0.0",
+	"description": "Example: render PDF reports in the background using @anephenix/job-queue and pdfkit",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"worker": "tsx src/start-worker.ts",
+		"add-job": "tsx src/add-job.ts"
+	},
+	"dependencies": {
+		"@anephenix/job-queue": "file:../..",
+		"better-sqlite3": "^13.0.3",
+		"pdfkit": "^0.19.1"
+	},
+	"devDependencies": {
+		"@types/better-sqlite3": "^9.6.0",
+		"@types/node": "^26.0.0",
+		"@types/pdfkit": "^0.17.6",
+		"tsx": "^4.19.4",
+		"typescript": "^7.0.2"
+	}
+}

--- a/examples/pdf-report-generation/sample/invoice.json
+++ b/examples/pdf-report-generation/sample/invoice.json
@@ -1,0 +1,14 @@
+{
+	"title": "Invoice #1042",
+	"customer": "Acme Corp",
+	"items": [
+		{ "description": "Consulting services", "quantity": 10, "unitPrice": 150 },
+		{ "description": "Software license", "quantity": 1, "unitPrice": 499 },
+		{ "description": "Onboarding support", "quantity": 4, "unitPrice": 85 },
+		{
+			"description": "Priority support (monthly)",
+			"quantity": 3,
+			"unitPrice": 120
+		}
+	]
+}

--- a/examples/pdf-report-generation/src/add-job.ts
+++ b/examples/pdf-report-generation/src/add-job.ts
@@ -1,0 +1,26 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import reportQueue from "./queue.ts";
+
+const inputPath = process.argv[2];
+
+if (!inputPath) {
+	console.error("Usage: npm run add-job -- <path-to-report-json-file>");
+	process.exit(1);
+}
+
+if (!existsSync(inputPath)) {
+	console.error(`File not found: ${inputPath}`);
+	process.exit(1);
+}
+
+const name = path.basename(inputPath, path.extname(inputPath));
+const outputPath = path.join("output", `${name}.pdf`);
+
+await reportQueue.add({
+	name: "generate-report",
+	data: { inputPath, outputPath },
+});
+
+console.log(`Queued ${inputPath} for report generation -> ${outputPath}`);
+await reportQueue.disconnect();

--- a/examples/pdf-report-generation/src/queue.ts
+++ b/examples/pdf-report-generation/src/queue.ts
@@ -1,0 +1,16 @@
+import { type Hooks, SQLiteQueue } from "@anephenix/job-queue";
+import db from "./sqlite.ts";
+
+// Creates the job_queue_jobs table if it doesn't already exist.
+// Safe to call every time the process starts.
+SQLiteQueue.migrate(db);
+
+type QueueOptions = { queueKey: string; db: typeof db; hooks: Partial<Hooks> };
+const queueOptions: QueueOptions = {
+	queueKey: "pdf-report-generation",
+	db,
+	hooks: {},
+};
+const reportQueue = new SQLiteQueue(queueOptions);
+
+export default reportQueue;

--- a/examples/pdf-report-generation/src/sqlite.ts
+++ b/examples/pdf-report-generation/src/sqlite.ts
@@ -1,0 +1,7 @@
+// A local SQLite database file is used so that this example can be run
+// without needing to install and run Redis or Postgres.
+import Database from "better-sqlite3";
+
+const db = new Database("./job-queue.db");
+
+export default db;

--- a/examples/pdf-report-generation/src/start-worker.ts
+++ b/examples/pdf-report-generation/src/start-worker.ts
@@ -1,0 +1,12 @@
+import reportWorker from "./worker.ts";
+
+console.log("Report worker started, polling for jobs...");
+console.log("Press Ctrl+C to stop.");
+
+process.on("SIGINT", async () => {
+	console.log("\nStopping worker...");
+	await reportWorker.stop();
+	process.exit(0);
+});
+
+await reportWorker.start();

--- a/examples/pdf-report-generation/src/worker.ts
+++ b/examples/pdf-report-generation/src/worker.ts
@@ -1,0 +1,102 @@
+import { createWriteStream } from "node:fs";
+import { mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { type Job, Worker } from "@anephenix/job-queue";
+import PDFDocument from "pdfkit";
+import reportQueue from "./queue.ts";
+
+type LineItem = { description: string; quantity: number; unitPrice: number };
+type InvoiceData = { title: string; customer: string; items: LineItem[] };
+
+type ReportJob = Job & {
+	data: {
+		inputPath: string;
+		outputPath: string;
+	};
+};
+
+const COLUMNS = [
+	{ label: "Description", x: 50, width: 260 },
+	{ label: "Qty", x: 310, width: 60 },
+	{ label: "Unit price", x: 370, width: 80 },
+	{ label: "Total", x: 450, width: 80 },
+];
+const PAGE_BOTTOM = 750;
+
+function formatCurrency(amount: number): string {
+	return `$${amount.toFixed(2)}`;
+}
+
+function renderInvoice(data: InvoiceData, outputPath: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const doc = new PDFDocument({ margin: 50 });
+		const stream = createWriteStream(outputPath);
+		doc.pipe(stream);
+		stream.on("finish", resolve);
+		stream.on("error", reject);
+
+		doc.fontSize(20).text(data.title);
+		doc.moveDown(0.5);
+		doc.fontSize(12).text(`Customer: ${data.customer}`);
+		doc.moveDown(1.5);
+
+		let y = doc.y;
+		const drawRow = (values: string[], bold = false): void => {
+			if (y > PAGE_BOTTOM) {
+				doc.addPage();
+				y = doc.y;
+			}
+			doc.font(bold ? "Helvetica-Bold" : "Helvetica").fontSize(10);
+			COLUMNS.forEach((column, index) => {
+				doc.text(values[index], column.x, y, { width: column.width });
+			});
+			y += 20;
+		};
+
+		drawRow(
+			COLUMNS.map((c) => c.label),
+			true,
+		);
+
+		let grandTotal = 0;
+		for (const item of data.items) {
+			const total = item.quantity * item.unitPrice;
+			grandTotal += total;
+			drawRow([
+				item.description,
+				String(item.quantity),
+				formatCurrency(item.unitPrice),
+				formatCurrency(total),
+			]);
+		}
+
+		y += 10;
+		drawRow(["", "", "Grand total", formatCurrency(grandTotal)], true);
+
+		doc.end();
+	});
+}
+
+class ReportWorker extends Worker {
+	async processJob(job: Job): Promise<void> {
+		this.status = "processing";
+		const { inputPath, outputPath } = (job as ReportJob).data;
+
+		try {
+			console.log(`Rendering report ${inputPath} -> ${outputPath}`);
+			const raw = await readFile(inputPath, "utf-8");
+			const data = JSON.parse(raw) as InvoiceData;
+			await mkdir(path.dirname(outputPath), { recursive: true });
+			await renderInvoice(data, outputPath);
+			console.log(`Finished rendering ${outputPath}`);
+			await this.completeJob(job);
+		} catch (err) {
+			console.error(`Error rendering report ${inputPath}:`, err);
+			await this.failJob(job);
+		}
+	}
+}
+
+const reportWorker = new ReportWorker(reportQueue);
+
+export default reportWorker;

--- a/examples/pdf-report-generation/tsconfig.json
+++ b/examples/pdf-report-generation/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"esModuleInterop": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"]
+}

--- a/examples/webhook-delivery/.gitignore
+++ b/examples/webhook-delivery/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+job-queue.db
+job-queue.db-shm
+job-queue.db-wal

--- a/examples/webhook-delivery/README.md
+++ b/examples/webhook-delivery/README.md
@@ -1,0 +1,85 @@
+# Example: Webhook delivery with retries
+
+This example shows how to use [`@anephenix/job-queue`](https://github.com/anephenix/job-queue)
+to deliver webhooks in the background, retrying with backoff when
+delivery fails. Unlike the other examples, this one is built around the
+queue's **hooks**, `fail` and `retry`, rather than just `add`/`take`.
+
+It uses `SQLiteQueue`, so there's no need to run Redis or Postgres.
+
+### How it works
+
+-   `src/queue.ts` creates a `SQLiteQueue` called `webhook-delivery`,
+    with hooks wired up on `fail` and `retry`:
+    -   The `fail` hook fires whenever a delivery attempt fails. It looks
+        up how many times that job has already failed and, if it hasn't
+        used up its retry budget (3 attempts, with 1s / 3s / 8s delays),
+        schedules a call to `queue.retry(job)` after the backoff delay.
+        Once the budget is used up, it logs that it's giving up and
+        leaves the job failed.
+    -   The `retry` hook just logs that the job has been put back in the
+        queue.
+-   `src/worker.ts` defines a `Worker` subclass that POSTs the job's
+    payload to its target URL, completing the job on a `2xx` response
+    and failing it (triggering the hook above) otherwise.
+-   `src/receiver.ts` is a small HTTP server standing in for a real
+    webhook endpoint. It deliberately fails the first couple of requests
+    it receives before succeeding, so you can see the retry/backoff path
+    happen without needing a real flaky endpoint.
+-   `src/add-job.ts` is a small CLI script that queues a webhook
+    delivery.
+-   `src/start-worker.ts` starts the worker, which polls the queue and
+    processes jobs as they arrive.
+
+Job attempt counts are tracked in memory, scoped to the running worker
+process — a production setup would persist that alongside the job so
+retries survive a worker restart. The `fail`/`retry` hooks themselves
+work identically on `Queue` (Redis) and `PostgresQueue`.
+
+### Prerequisites
+
+-   Node.js
+
+### Setup
+
+From this directory:
+
+```shell
+npm install
+```
+
+### Usage
+
+1.  Start the (deliberately flaky) receiver:
+
+    ```shell
+    npm run receiver
+    ```
+
+2.  In another terminal, queue a webhook delivery to it:
+
+    ```shell
+    npm run add-job -- http://localhost:4000/webhook '{"event":"user.created","userId":42}'
+    ```
+
+3.  In a third terminal, start the worker:
+
+    ```shell
+    npm run worker
+    ```
+
+You'll see the first two delivery attempts fail, with the worker
+logging that it's retrying after a backoff delay each time, and the
+third attempt succeed and complete the job. Watch the receiver's
+terminal too — it logs every request it gets, and which ones it's
+rejecting.
+
+To see a job give up entirely, make the receiver fail more requests
+than there are retries for:
+
+```shell
+FAIL_FIRST_N=10 npm run receiver
+```
+
+Queue another webhook and start the worker — after 3 failed retries
+you'll see `Giving up` logged, and the job stays in the `failed` state.

--- a/examples/webhook-delivery/package.json
+++ b/examples/webhook-delivery/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "webhook-delivery-example",
+	"version": "1.0.0",
+	"description": "Example: deliver webhooks with retry-with-backoff using @anephenix/job-queue's fail/retry hooks",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"receiver": "tsx src/receiver.ts",
+		"worker": "tsx src/start-worker.ts",
+		"add-job": "tsx src/add-job.ts"
+	},
+	"dependencies": {
+		"@anephenix/job-queue": "file:../..",
+		"better-sqlite3": "^13.0.3"
+	},
+	"devDependencies": {
+		"@types/better-sqlite3": "^9.6.0",
+		"@types/node": "^26.0.0",
+		"tsx": "^4.19.4",
+		"typescript": "^7.0.2"
+	}
+}

--- a/examples/webhook-delivery/src/add-job.ts
+++ b/examples/webhook-delivery/src/add-job.ts
@@ -1,0 +1,27 @@
+import crypto from "node:crypto";
+import webhookQueue from "./queue.ts";
+
+const [url, payloadArg] = process.argv.slice(2);
+
+if (!url || !payloadArg) {
+	console.error("Usage: npm run add-job -- <url> '<json-payload>'");
+	process.exit(1);
+}
+
+let payload: unknown;
+try {
+	payload = JSON.parse(payloadArg);
+} catch {
+	console.error("Payload must be valid JSON.");
+	process.exit(1);
+}
+
+const id = crypto.randomUUID();
+
+await webhookQueue.add({
+	name: "webhook-delivery",
+	data: { id, url, payload },
+});
+
+console.log(`Queued webhook ${id} -> ${url}`);
+await webhookQueue.disconnect();

--- a/examples/webhook-delivery/src/queue.ts
+++ b/examples/webhook-delivery/src/queue.ts
@@ -1,0 +1,60 @@
+import { type Hooks, type Job, SQLiteQueue } from "@anephenix/job-queue";
+import db from "./sqlite.ts";
+
+// Creates the job_queue_jobs table if it doesn't already exist.
+// Safe to call every time the process starts.
+SQLiteQueue.migrate(db);
+
+type WebhookJobData = { id: string };
+
+// How long to wait before each retry. The Nth entry is the delay before
+// the (N+1)th attempt. Once a job has used up all of these, it's left
+// failed rather than retried again.
+const BACKOFF_DELAYS_MS = [1000, 3000, 8000];
+
+// Tracks how many times each job has failed so far. Scoped to this
+// worker process - a production setup would persist this alongside the
+// job itself so retries survive a restart.
+const attemptsByJobId = new Map<string, number>();
+
+let webhookQueue: SQLiteQueue;
+
+const hooks: Partial<Hooks> = {
+	fail: {
+		post: async (job?: Job) => {
+			if (!job) return;
+			const { id } = job.data as WebhookJobData;
+			const attempt = attemptsByJobId.get(id) ?? 0;
+
+			if (attempt >= BACKOFF_DELAYS_MS.length) {
+				console.log(
+					`Webhook ${id} failed after ${attempt} attempts. Giving up.`,
+				);
+				return;
+			}
+
+			const delay = BACKOFF_DELAYS_MS[attempt];
+			attemptsByJobId.set(id, attempt + 1);
+			console.log(
+				`Webhook ${id} failed (attempt ${attempt + 1}/${BACKOFF_DELAYS_MS.length + 1}). Retrying in ${delay}ms...`,
+			);
+			setTimeout(() => {
+				webhookQueue
+					.retry(job)
+					.catch((err) => console.error(`Failed to retry webhook ${id}:`, err));
+			}, delay);
+		},
+	},
+	retry: {
+		post: async (job?: Job) => {
+			if (!job) return;
+			const { id } = job.data as WebhookJobData;
+			console.log(`Webhook ${id} is back in the queue for another attempt.`);
+		},
+	},
+};
+
+const queueOptions = { queueKey: "webhook-delivery", db, hooks };
+webhookQueue = new SQLiteQueue(queueOptions);
+
+export default webhookQueue;

--- a/examples/webhook-delivery/src/receiver.ts
+++ b/examples/webhook-delivery/src/receiver.ts
@@ -1,0 +1,45 @@
+import { createServer } from "node:http";
+
+// A stand-in for a real webhook endpoint. It fails the first FAIL_FIRST_N
+// requests it receives (500), then succeeds for every request after
+// that - so running the worker against it exercises the retry/backoff
+// path before eventually completing the job.
+const PORT = process.env.PORT ? Number(process.env.PORT) : 4000;
+const FAIL_FIRST_N = process.env.FAIL_FIRST_N
+	? Number(process.env.FAIL_FIRST_N)
+	: 2;
+
+let requestCount = 0;
+
+const server = createServer((req, res) => {
+	if (req.method !== "POST") {
+		res.writeHead(404);
+		res.end();
+		return;
+	}
+
+	let body = "";
+	req.on("data", (chunk) => {
+		body += chunk;
+	});
+	req.on("end", () => {
+		requestCount += 1;
+		console.log(`Received webhook #${requestCount}: ${body}`);
+
+		if (requestCount <= FAIL_FIRST_N) {
+			console.log(`  -> simulating failure (${requestCount}/${FAIL_FIRST_N})`);
+			res.writeHead(500, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ error: "simulated failure" }));
+			return;
+		}
+
+		console.log("  -> accepted");
+		res.writeHead(200, { "Content-Type": "application/json" });
+		res.end(JSON.stringify({ ok: true }));
+	});
+});
+
+server.listen(PORT, () => {
+	console.log(`Webhook receiver listening on http://localhost:${PORT}`);
+	console.log(`Will fail the first ${FAIL_FIRST_N} requests, then succeed.`);
+});

--- a/examples/webhook-delivery/src/sqlite.ts
+++ b/examples/webhook-delivery/src/sqlite.ts
@@ -1,0 +1,7 @@
+// A local SQLite database file is used so that this example can be run
+// without needing to install and run Redis or Postgres.
+import Database from "better-sqlite3";
+
+const db = new Database("./job-queue.db");
+
+export default db;

--- a/examples/webhook-delivery/src/start-worker.ts
+++ b/examples/webhook-delivery/src/start-worker.ts
@@ -1,0 +1,12 @@
+import webhookWorker from "./worker.ts";
+
+console.log("Webhook worker started, polling for jobs...");
+console.log("Press Ctrl+C to stop.");
+
+process.on("SIGINT", async () => {
+	console.log("\nStopping worker...");
+	await webhookWorker.stop();
+	process.exit(0);
+});
+
+await webhookWorker.start();

--- a/examples/webhook-delivery/src/worker.ts
+++ b/examples/webhook-delivery/src/worker.ts
@@ -1,0 +1,41 @@
+import { type Job, Worker } from "@anephenix/job-queue";
+import webhookQueue from "./queue.ts";
+
+type WebhookJob = Job & {
+	data: {
+		id: string;
+		url: string;
+		payload: unknown;
+	};
+};
+
+class WebhookWorker extends Worker {
+	async processJob(job: Job): Promise<void> {
+		this.status = "processing";
+		const { id, url, payload } = (job as WebhookJob).data;
+
+		try {
+			const response = await fetch(url, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(payload),
+				signal: AbortSignal.timeout(5000),
+			});
+
+			if (!response.ok) {
+				throw new Error(`Webhook responded with status ${response.status}`);
+			}
+
+			console.log(`Delivered webhook ${id} to ${url}`);
+			await this.completeJob(job);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			console.error(`Failed to deliver webhook ${id} to ${url}: ${message}`);
+			await this.failJob(job);
+		}
+	}
+}
+
+const webhookWorker = new WebhookWorker(webhookQueue);
+
+export default webhookWorker;

--- a/examples/webhook-delivery/tsconfig.json
+++ b/examples/webhook-delivery/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"esModuleInterop": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"allowImportingTsExtensions": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- Adds six self-contained example projects under `examples/`, each pairing a real-world use case with one of the library's backends, plus a top-level `examples/README.md` indexing them all:
  - **mp4-to-hls** (SQLite) — transcode an uploaded video into HLS (`.m3u8` + `.ts`) with ffmpeg
  - **email-sending** (Redis) — send email in the background via nodemailer + an auto-created Ethereal test account
  - **csv-import** (Postgres) — stream-parse a CSV file and bulk-insert its rows
  - **image-thumbnails** (SQLite) — resize images into multiple sizes with sharp; the fastest one to try, good as a first example
  - **webhook-delivery** (SQLite) — retry failed HTTP deliveries with backoff, the only example built around the queue's `fail`/`retry` hooks rather than just `add`/`take`
  - **pdf-report-generation** (SQLite) — render a PDF invoice with pdfkit, no headless browser needed
- Each example depends on the library via `file:../..` and follows the same shape (`src/queue.ts`, `src/worker.ts`, `src/add-job.ts`, `src/start-worker.ts`), so the pattern is easy to compare across examples and backends.
- Each example's own README documents its prerequisites and exact commands to run it.

## Test plan
- [x] Every example: `npm install`, `npx tsc --noEmit` — clean
- [x] `npx @biomejs/biome check` — clean on all example files
- [x] Ran each example end-to-end locally and verified output:
  - mp4-to-hls: generated a test mp4, confirmed a valid `.m3u8` playlist + `.ts` segment
  - email-sending: queued and sent an email, confirmed an Ethereal preview URL
  - csv-import: queued and imported the sample CSV into a scratch Postgres database, confirmed all rows landed correctly and the job reached `completed`
  - image-thumbnails: generated a test image, confirmed three correctly-sized `.webp` outputs
  - webhook-delivery: confirmed both the retry-with-backoff path (fails twice, succeeds on 3rd attempt) and the exhausted-retries path (job ends `failed` after 3 retries)
  - pdf-report-generation: rendered the sample invoice, parsed the output PDF's text and confirmed all line items and the grand total are correct
- [x] `npm t` (root package, via pre-commit hook) — 69/69 tests pass, unaffected by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)